### PR TITLE
컨텐츠별 시급 페이지에 관문 합쳐보기 기능 추가

### DIFF
--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -87,6 +87,36 @@ type ContentDuration {
   userContentDuration: UserContentDuration!
 }
 
+type ContentGroup {
+  contentCategory: ContentCategory!
+  contentCategoryId: Int!
+  contentIds: [Int!]!
+  contents: [Content!]!
+  duration: Int!
+  durationText: String!
+  level: Int!
+  name: String!
+}
+
+input ContentGroupFilter {
+  contentIds: [Int!]
+}
+
+type ContentGroupWage {
+  contentGroup: ContentGroup!
+  goldAmountPerClear: Float!
+  goldAmountPerHour: Float!
+  krwAmountPerHour: Float!
+}
+
+input ContentGroupWageListFilter {
+  contentCategoryId: Int
+  includeContentRewardItemIds: [Int!]
+  includeIsBound: Boolean
+  includeIsSeeMore: Boolean
+  keyword: String
+}
+
 input ContentListFilter {
   contentCategoryId: Int
   includeIsSeeMore: Boolean
@@ -179,6 +209,10 @@ input ContentWageListFilter {
   keyword: String
 }
 
+input ContentsFilter {
+  ids: [Int!]
+}
+
 input CustomContentWageCalculateInput {
   minutes: Int!
   rewardItems: [CustomContentWageCalculateRewardItemInput!]!
@@ -228,6 +262,7 @@ type Mutation {
   contentRewardsReport(input: ContentRewardsReportInput!): ContentRewardsReportResult!
   customContentWageCalculate(input: CustomContentWageCalculateInput!): CustomContentWageCalculateResult!
   userContentDurationEdit(input: UserContentDurationEditInput!): UserContentDurationEditResult!
+  userContentDurationsEdit(input: UserContentDurationsEditInput!): UserContentDurationsEditResult!
   userContentRewardItemEdit(input: UserContentRewardItemEditInput!): UserContentRewardItemEditResult!
   userContentRewardsEdit(input: UserContentRewardsEditInput!): UserContentRewardsEditResult!
   userContentSeeMoreRewardsEdit(input: UserContentSeeMoreRewardsEditInput!): UserContentSeeMoreRewardsEditResult!
@@ -245,10 +280,13 @@ type Query {
   content(id: Int!): Content!
   contentCategories: [ContentCategory!]!
   contentDuration(id: Int!): ContentDuration!
+  contentGroup(filter: ContentGroupFilter): ContentGroup!
+  contentGroupWageList(filter: ContentGroupWageListFilter, orderBy: [OrderByArg!]): [ContentGroupWage!]!
   contentList(filter: ContentListFilter): [Content!]!
   contentRewardItem(id: Int!): ContentRewardItem!
   contentRewardItems(filter: ContentRewardItemsFilter): [ContentRewardItem!]!
   contentWageList(filter: ContentWageListFilter, orderBy: [OrderByArg!]): [ContentWage!]!
+  contents(filter: ContentsFilter): [Content!]!
   goldExchangeRate: UserGoldExchangeRate!
   marketItemList(filter: MarketItemListFilter): [MarketItem!]!
   marketItems(orderBy: [OrderByArg!], take: Int): [MarketItem!]!
@@ -284,6 +322,20 @@ input UserContentDurationEditInput {
 }
 
 type UserContentDurationEditResult {
+  ok: Boolean!
+}
+
+input UserContentDurationsEditInput {
+  contentDurations: [UserContentDurationsEditInputDuration!]!
+}
+
+input UserContentDurationsEditInputDuration {
+  id: Int!
+  minutes: Int!
+  seconds: Int!
+}
+
+type UserContentDurationsEditResult {
   ok: Boolean!
 }
 

--- a/src/backend/src/content/content.module.ts
+++ b/src/backend/src/content/content.module.ts
@@ -26,6 +26,11 @@ import { ContentCreateMutation } from './mutation/content-create.mutation';
 import { DataLoaderService } from 'src/dataloader/data-loader.service';
 import { UserContentSeeMoreRewardsEditMutation } from './mutation/user-content-see-more-rewards-edit.mutation';
 import { ContentDurationService } from './service/content-duration.service';
+import { ContentGroupResolver } from './object/content-group.resolver';
+import { ContentGroupWageListQuery } from './query/content-group-wage-list.query';
+import { UserContentDurationsEditMutation } from './mutation/user-content-durations-edit.mutation';
+import { ContentsQuery } from './query/contents.query';
+import { ContentGroupQuery } from './query/content-group.query';
 
 @Module({
   imports: [PrismaModule],
@@ -56,6 +61,11 @@ import { ContentDurationService } from './service/content-duration.service';
     DataLoaderService,
     UserContentSeeMoreRewardsEditMutation,
     ContentDurationService,
+    ContentGroupWageListQuery,
+    ContentGroupResolver,
+    UserContentDurationsEditMutation,
+    ContentsQuery,
+    ContentGroupQuery,
   ],
 })
 export class ContentModule {}

--- a/src/backend/src/content/mutation/user-content-durations-edit.mutation.ts
+++ b/src/backend/src/content/mutation/user-content-durations-edit.mutation.ts
@@ -1,0 +1,114 @@
+import { UseGuards } from '@nestjs/common';
+import {
+  Args,
+  Field,
+  InputType,
+  Int,
+  Mutation,
+  ObjectType,
+  Resolver,
+} from '@nestjs/graphql';
+import { AuthGuard } from 'src/auth/auth.guard';
+import { PrismaService } from 'src/prisma';
+import { UserContentService } from '../../user/service/user-content.service';
+import { CurrentUser } from 'src/common/decorator/current-user.decorator';
+import { User } from 'src/common/object/user.object';
+import { Prisma, UserRole } from '@prisma/client';
+import { ContentDurationService } from '../service/content-duration.service';
+
+@InputType()
+class UserContentDurationsEditInputDuration {
+  @Field()
+  id: number;
+
+  @Field(() => Int)
+  minutes: number;
+
+  @Field(() => Int)
+  seconds: number;
+}
+
+@InputType()
+class UserContentDurationsEditInput {
+  @Field(() => [UserContentDurationsEditInputDuration])
+  contentDurations: UserContentDurationsEditInputDuration[];
+}
+
+@ObjectType()
+class UserContentDurationsEditResult {
+  @Field(() => Boolean)
+  ok: boolean;
+}
+
+@Resolver()
+export class UserContentDurationsEditMutation {
+  constructor(
+    private prisma: PrismaService,
+    private userContentService: UserContentService,
+    private contentDurationService: ContentDurationService,
+  ) {}
+
+  @UseGuards(AuthGuard)
+  @Mutation(() => UserContentDurationsEditResult)
+  async userContentDurationsEdit(
+    @Args('input') input: UserContentDurationsEditInput,
+    @CurrentUser() user: User,
+  ) {
+    const { contentDurations } = input;
+
+    const promises = contentDurations.map(async ({ id, minutes, seconds }) => {
+      const totalSeconds = this.contentDurationService.getValidatedTotalSeconds(
+        {
+          minutes,
+          seconds,
+        },
+      );
+
+      await this.userContentService.validateUserContentDuration(id);
+
+      return await this.prisma.$transaction(async (tx) => {
+        if (user.role === UserRole.OWNER) {
+          await this.editDefaultContentDuration({ id, totalSeconds }, tx);
+        }
+
+        await tx.userContentDuration.update({
+          where: { id },
+          data: { isEdited: true, value: totalSeconds },
+        });
+      });
+    });
+
+    await Promise.all(promises);
+
+    return { ok: true };
+  }
+
+  async editDefaultContentDuration(
+    { id, totalSeconds }: { id: number; totalSeconds: number },
+    tx: Prisma.TransactionClient,
+  ) {
+    const { contentDurationId } =
+      await tx.userContentDuration.findUniqueOrThrow({
+        where: { id },
+      });
+
+    await tx.userContentDuration.updateMany({
+      where: {
+        contentDurationId,
+        isEdited: false,
+      },
+      data: {
+        value: totalSeconds,
+      },
+    });
+
+    await tx.contentDuration.update({
+      where: {
+        id: contentDurationId,
+      },
+      data: {
+        defaultValue: totalSeconds,
+      },
+    });
+  }
+}

--- a/src/backend/src/content/object/content-group-wage.object.ts
+++ b/src/backend/src/content/object/content-group-wage.object.ts
@@ -1,0 +1,17 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql';
+import { ContentGroup } from './content-group.object';
+
+@ObjectType()
+export class ContentGroupWage {
+  @Field(() => ContentGroup)
+  contentGroup: ContentGroup;
+
+  @Field(() => Float)
+  krwAmountPerHour: number;
+
+  @Field(() => Float)
+  goldAmountPerHour: number;
+
+  @Field(() => Float)
+  goldAmountPerClear: number;
+}

--- a/src/backend/src/content/object/content-group.object.ts
+++ b/src/backend/src/content/object/content-group.object.ts
@@ -1,0 +1,16 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ContentGroup {
+  @Field()
+  contentCategoryId: number;
+
+  @Field(() => [Number])
+  contentIds: number[];
+
+  @Field()
+  level: number;
+
+  @Field()
+  name: string;
+}

--- a/src/backend/src/content/object/content-group.resolver.ts
+++ b/src/backend/src/content/object/content-group.resolver.ts
@@ -1,0 +1,55 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { ContentCategory } from './content-category.object';
+import { UserContentService } from '../../user/service/user-content.service';
+import { DataLoaderService } from 'src/dataloader/data-loader.service';
+import { ContentGroup } from './content-group.object';
+import { Content } from './content.object';
+import { PrismaService } from 'src/prisma';
+
+@Resolver(() => ContentGroup)
+export class ContentGroupResolver {
+  constructor(
+    private userContentService: UserContentService,
+    private dataLoaderService: DataLoaderService,
+    private prisma: PrismaService,
+  ) {}
+
+  @ResolveField(() => [Content])
+  async contents(@Parent() contentGroup: ContentGroup) {
+    return await this.prisma.content.findMany({
+      where: {
+        id: { in: contentGroup.contentIds },
+      },
+    });
+  }
+
+  @ResolveField(() => ContentCategory)
+  async contentCategory(@Parent() contentGroup: ContentGroup) {
+    return await this.dataLoaderService.contentCategory.findUniqueOrThrowById(
+      contentGroup.contentCategoryId,
+    );
+  }
+
+  @ResolveField(() => Number)
+  async duration(@Parent() contentGroup: ContentGroup) {
+    let duration = 0;
+
+    for (const contentId of contentGroup.contentIds) {
+      const contentDuration = await this.userContentService.getContentDuration(
+        contentId,
+      );
+      duration += contentDuration;
+    }
+
+    return duration;
+  }
+
+  @ResolveField(() => String)
+  async durationText(@Parent() contentGroup: ContentGroup) {
+    const durationInSeconds = await this.duration(contentGroup);
+    const minutes = Math.floor(durationInSeconds / 60);
+    const seconds = durationInSeconds % 60;
+
+    return seconds === 0 ? `${minutes}분` : `${minutes}분 ${seconds}초`;
+  }
+}

--- a/src/backend/src/content/query/content-group-wage-list.query.ts
+++ b/src/backend/src/content/query/content-group-wage-list.query.ts
@@ -1,0 +1,131 @@
+import { Args, Field, InputType, Query, Resolver } from '@nestjs/graphql';
+import { PrismaService } from 'src/prisma';
+import { Prisma } from '@prisma/client';
+import { ContentWageService } from '../service/content-wage.service';
+import { ContentWageFilter } from '../object/content-wage.object';
+import { OrderByArg } from 'src/common/object/order-by-arg.object';
+import _ from 'lodash';
+import { ContentGroupWage } from '../object/content-group-wage.object';
+
+@InputType()
+export class ContentGroupWageListFilter extends ContentWageFilter {
+  @Field({ nullable: true })
+  contentCategoryId?: number;
+
+  @Field(() => String, { nullable: true })
+  keyword?: string;
+}
+
+@Resolver()
+export class ContentGroupWageListQuery {
+  constructor(
+    private prisma: PrismaService,
+    private contentWageService: ContentWageService,
+  ) {}
+
+  @Query(() => [ContentGroupWage])
+  async contentGroupWageList(
+    @Args('filter', { nullable: true }) filter?: ContentGroupWageListFilter,
+    @Args('orderBy', {
+      type: () => [OrderByArg],
+      nullable: true,
+    })
+    orderBy?: OrderByArg[],
+  ) {
+    const contents = await this.prisma.content.findMany({
+      where: this.buildWhereArgs(filter),
+      orderBy: [
+        {
+          contentCategory: {
+            id: 'asc',
+          },
+        },
+        {
+          level: 'asc',
+        },
+        {
+          id: 'asc',
+        },
+      ],
+      include: {
+        contentCategory: true,
+        contentSeeMoreRewards: {
+          include: {
+            contentRewardItem: true,
+          },
+        },
+      },
+    });
+
+    const contentGroups = _.groupBy(
+      contents,
+      (content) => `${content.name}_${content.contentCategoryId}`,
+    );
+
+    const promises = Object.entries(contentGroups).map(
+      async ([_, groupContents]) => {
+        const contentIds = groupContents.map((content) => content.id);
+
+        const representative = groupContents[0];
+
+        const wage = await this.contentWageService.getContentGroupWage(
+          contentIds,
+          {
+            includeIsBound: filter?.includeIsBound,
+            includeContentRewardItemIds: filter?.includeContentRewardItemIds,
+            includeIsSeeMore: filter?.includeIsSeeMore,
+          },
+        );
+
+        return {
+          contentGroup: {
+            contentIds,
+            name: representative.name,
+            level: representative.level,
+            contentCategoryId: representative.contentCategoryId,
+          },
+          ...wage,
+        };
+      },
+    );
+
+    const result = orderBy
+      ? _.orderBy(
+          await Promise.all(promises),
+          orderBy.map((order) => order.field),
+          orderBy.map((order) => order.order),
+        )
+      : await Promise.all(promises);
+
+    return result;
+  }
+
+  buildWhereArgs(filter?: ContentGroupWageListFilter) {
+    const where: Prisma.ContentWhereInput = {};
+
+    if (filter?.contentCategoryId) {
+      where.contentCategoryId = filter.contentCategoryId;
+    }
+
+    if (filter?.keyword) {
+      where.OR = [
+        {
+          name: {
+            contains: filter.keyword,
+            mode: 'insensitive',
+          },
+        },
+        {
+          contentCategory: {
+            name: {
+              contains: filter.keyword,
+              mode: 'insensitive',
+            },
+          },
+        },
+      ];
+    }
+
+    return where;
+  }
+}

--- a/src/backend/src/content/query/content-group.query.ts
+++ b/src/backend/src/content/query/content-group.query.ts
@@ -1,0 +1,65 @@
+import { Args, Field, InputType, Query, Resolver } from '@nestjs/graphql';
+import { PrismaService } from 'src/prisma';
+import { Prisma } from '@prisma/client';
+import { ContentGroup } from '../object/content-group.object';
+
+@InputType()
+export class ContentGroupFilter {
+  @Field(() => [Number], { nullable: true })
+  contentIds?: number[];
+}
+
+@Resolver()
+export class ContentGroupQuery {
+  constructor(private prisma: PrismaService) {}
+
+  @Query(() => ContentGroup)
+  async contentGroup(
+    @Args('filter', { nullable: true }) filter?: ContentGroupFilter,
+  ) {
+    const contents = await this.prisma.content.findMany({
+      where: this.buildWhereArgs(filter),
+      orderBy: [
+        {
+          contentCategory: {
+            id: 'asc',
+          },
+        },
+        {
+          level: 'asc',
+        },
+        {
+          id: 'asc',
+        },
+      ],
+    });
+
+    for (const content of contents) {
+      if (content.level !== contents[0].level) {
+        throw new Error('Content level is not the same');
+      }
+
+      if (content.contentCategoryId !== contents[0].contentCategoryId) {
+        throw new Error('Content category is not the same');
+      }
+    }
+
+    return {
+      contentIds: contents.map((content) => content.id),
+      level: contents[0].level,
+      name: contents[0].name,
+    };
+  }
+
+  buildWhereArgs(filter?: ContentGroupFilter) {
+    const where: Prisma.ContentWhereInput = {};
+
+    if (filter?.contentIds) {
+      where.id = {
+        in: filter.contentIds,
+      };
+    }
+
+    return where;
+  }
+}

--- a/src/backend/src/content/query/contents.query.ts
+++ b/src/backend/src/content/query/contents.query.ts
@@ -1,0 +1,48 @@
+import { Args, Field, InputType, Query, Resolver } from '@nestjs/graphql';
+import { PrismaService } from 'src/prisma';
+import { Content } from '../object/content.object';
+import { Prisma } from '@prisma/client';
+import _ from 'lodash';
+
+@InputType()
+export class ContentsFilter {
+  @Field(() => [Number], { nullable: true })
+  ids?: number[];
+}
+
+@Resolver()
+export class ContentsQuery {
+  constructor(private prisma: PrismaService) {}
+
+  @Query(() => [Content])
+  async contents(@Args('filter', { nullable: true }) filter?: ContentsFilter) {
+    return await this.prisma.content.findMany({
+      where: this.buildWhereArgs(filter),
+      orderBy: [
+        {
+          contentCategory: {
+            id: 'asc',
+          },
+        },
+        {
+          level: 'asc',
+        },
+        {
+          id: 'asc',
+        },
+      ],
+    });
+  }
+
+  buildWhereArgs(filter?: ContentsFilter) {
+    const where: Prisma.ContentWhereInput = {};
+
+    if (filter?.ids) {
+      where.id = {
+        in: filter.ids,
+      };
+    }
+
+    return where;
+  }
+}

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -112,6 +112,38 @@ export type ContentDuration = {
   userContentDuration: UserContentDuration;
 };
 
+export type ContentGroup = {
+  __typename?: 'ContentGroup';
+  contentCategory: ContentCategory;
+  contentCategoryId: Scalars['Int']['output'];
+  contentIds: Array<Scalars['Int']['output']>;
+  contents: Array<Content>;
+  duration: Scalars['Int']['output'];
+  durationText: Scalars['String']['output'];
+  level: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type ContentGroupFilter = {
+  contentIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type ContentGroupWage = {
+  __typename?: 'ContentGroupWage';
+  contentGroup: ContentGroup;
+  goldAmountPerClear: Scalars['Float']['output'];
+  goldAmountPerHour: Scalars['Float']['output'];
+  krwAmountPerHour: Scalars['Float']['output'];
+};
+
+export type ContentGroupWageListFilter = {
+  contentCategoryId?: InputMaybe<Scalars['Int']['input']>;
+  includeContentRewardItemIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  includeIsBound?: InputMaybe<Scalars['Boolean']['input']>;
+  includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  keyword?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type ContentListFilter = {
   contentCategoryId?: InputMaybe<Scalars['Int']['input']>;
   includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
@@ -210,6 +242,10 @@ export type ContentWageListFilter = {
   keyword?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type ContentsFilter = {
+  ids?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
 export type CustomContentWageCalculateInput = {
   minutes: Scalars['Int']['input'];
   rewardItems: Array<CustomContentWageCalculateRewardItemInput>;
@@ -257,6 +293,7 @@ export type Mutation = {
   contentRewardsReport: ContentRewardsReportResult;
   customContentWageCalculate: CustomContentWageCalculateResult;
   userContentDurationEdit: UserContentDurationEditResult;
+  userContentDurationsEdit: UserContentDurationsEditResult;
   userContentRewardItemEdit: UserContentRewardItemEditResult;
   userContentRewardsEdit: UserContentRewardsEditResult;
   userContentSeeMoreRewardsEdit: UserContentSeeMoreRewardsEditResult;
@@ -281,6 +318,11 @@ export type MutationCustomContentWageCalculateArgs = {
 
 export type MutationUserContentDurationEditArgs = {
   input: UserContentDurationEditInput;
+};
+
+
+export type MutationUserContentDurationsEditArgs = {
+  input: UserContentDurationsEditInput;
 };
 
 
@@ -315,10 +357,13 @@ export type Query = {
   content: Content;
   contentCategories: Array<ContentCategory>;
   contentDuration: ContentDuration;
+  contentGroup: ContentGroup;
+  contentGroupWageList: Array<ContentGroupWage>;
   contentList: Array<Content>;
   contentRewardItem: ContentRewardItem;
   contentRewardItems: Array<ContentRewardItem>;
   contentWageList: Array<ContentWage>;
+  contents: Array<Content>;
   goldExchangeRate: UserGoldExchangeRate;
   marketItemList: Array<MarketItem>;
   marketItems: Array<MarketItem>;
@@ -348,6 +393,17 @@ export type QueryContentDurationArgs = {
 };
 
 
+export type QueryContentGroupArgs = {
+  filter?: InputMaybe<ContentGroupFilter>;
+};
+
+
+export type QueryContentGroupWageListArgs = {
+  filter?: InputMaybe<ContentGroupWageListFilter>;
+  orderBy?: InputMaybe<Array<OrderByArg>>;
+};
+
+
 export type QueryContentListArgs = {
   filter?: InputMaybe<ContentListFilter>;
 };
@@ -366,6 +422,11 @@ export type QueryContentRewardItemsArgs = {
 export type QueryContentWageListArgs = {
   filter?: InputMaybe<ContentWageListFilter>;
   orderBy?: InputMaybe<Array<OrderByArg>>;
+};
+
+
+export type QueryContentsArgs = {
+  filter?: InputMaybe<ContentsFilter>;
 };
 
 
@@ -410,6 +471,21 @@ export type UserContentDurationEditInput = {
 
 export type UserContentDurationEditResult = {
   __typename?: 'UserContentDurationEditResult';
+  ok: Scalars['Boolean']['output'];
+};
+
+export type UserContentDurationsEditInput = {
+  contentDurations: Array<UserContentDurationsEditInputDuration>;
+};
+
+export type UserContentDurationsEditInputDuration = {
+  id: Scalars['Int']['input'];
+  minutes: Scalars['Int']['input'];
+  seconds: Scalars['Int']['input'];
+};
+
+export type UserContentDurationsEditResult = {
+  __typename?: 'UserContentDurationsEditResult';
   ok: Scalars['Boolean']['output'];
 };
 
@@ -555,6 +631,13 @@ export type ContentWageListBarChartQueryVariables = Exact<{
 
 export type ContentWageListBarChartQuery = { __typename?: 'Query', contentWageList: Array<{ __typename?: 'ContentWage', goldAmountPerHour: number, krwAmountPerHour: number, content: { __typename?: 'Content', displayName: string, contentCategory: { __typename?: 'ContentCategory', name: string } } }> };
 
+export type ContentGroupWageListTableQueryVariables = Exact<{
+  filter?: InputMaybe<ContentGroupWageListFilter>;
+}>;
+
+
+export type ContentGroupWageListTableQuery = { __typename?: 'Query', contentGroupWageList: Array<{ __typename?: 'ContentGroupWage', goldAmountPerHour: number, goldAmountPerClear: number, krwAmountPerHour: number, contentGroup: { __typename?: 'ContentGroup', contentIds: Array<number>, durationText: string, level: number, name: string, contentCategory: { __typename?: 'ContentCategory', imageUrl: string, name: string } } }> };
+
 export type ContentWageListTableQueryVariables = Exact<{
   filter?: InputMaybe<ContentWageListFilter>;
 }>;
@@ -655,6 +738,13 @@ export type ContentDetailsDialogWageSectionQueryVariables = Exact<{
 
 export type ContentDetailsDialogWageSectionQuery = { __typename?: 'Query', content: { __typename?: 'Content', durationText: string, id: number, contentDuration: { __typename?: 'ContentDuration', id: number }, wage: { __typename?: 'ContentWage', krwAmountPerHour: number, goldAmountPerHour: number, goldAmountPerClear: number } } };
 
+export type ContentGroupDetailsDialogQueryVariables = Exact<{
+  contentIds: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
+}>;
+
+
+export type ContentGroupDetailsDialogQuery = { __typename?: 'Query', contentGroup: { __typename?: 'ContentGroup', name: string, contents: Array<{ __typename?: 'Content', gate?: number | null, id: number }> } };
+
 export type ContentRewardReportDialogQueryVariables = Exact<{
   id: Scalars['Int']['input'];
 }>;
@@ -682,6 +772,20 @@ export type UserContentDurationEditMutationVariables = Exact<{
 
 
 export type UserContentDurationEditMutation = { __typename?: 'Mutation', userContentDurationEdit: { __typename?: 'UserContentDurationEditResult', ok: boolean } };
+
+export type UserContentGroupDurationEditDialogQueryVariables = Exact<{
+  ids: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
+}>;
+
+
+export type UserContentGroupDurationEditDialogQuery = { __typename?: 'Query', contentGroup: { __typename?: 'ContentGroup', name: string }, contents: Array<{ __typename?: 'Content', gate?: number | null, contentDuration: { __typename?: 'ContentDuration', userContentDuration: { __typename?: 'UserContentDuration', id: number, value: number } } }> };
+
+export type UserContentDurationsEditMutationVariables = Exact<{
+  input: UserContentDurationsEditInput;
+}>;
+
+
+export type UserContentDurationsEditMutation = { __typename?: 'Mutation', userContentDurationsEdit: { __typename?: 'UserContentDurationsEditResult', ok: boolean } };
 
 export type UserContentRewardEditDialogQueryVariables = Exact<{
   id: Scalars['Int']['input'];
@@ -728,6 +832,7 @@ export const ValidateRewardsTabDocument = {"kind":"Document","definitions":[{"ki
 export const ContentRewardListPieChartDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardListPieChart"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentListFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"price"}},{"kind":"Field","name":{"kind":"Name","value":"pieColor"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"quantity"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"price"}},{"kind":"Field","name":{"kind":"Name","value":"pieColor"}}]}}]}}]}}]}}]} as unknown as DocumentNode<ContentRewardListPieChartQuery, ContentRewardListPieChartQueryVariables>;
 export const ContentRewardListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentListFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"quantity"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"level"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItems"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentRewardListTableQuery, ContentRewardListTableQueryVariables>;
 export const ContentWageListBarChartDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentWageListBarChart"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentWageListFilter"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"OrderByArg"}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentWageList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}}]}}]}}]} as unknown as DocumentNode<ContentWageListBarChartQuery, ContentWageListBarChartQueryVariables>;
+export const ContentGroupWageListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentGroupWageListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentGroupWageListFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroupWageList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroup"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentIds"}},{"kind":"Field","name":{"kind":"Name","value":"durationText"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}}]}}]}}]} as unknown as DocumentNode<ContentGroupWageListTableQuery, ContentGroupWageListTableQueryVariables>;
 export const ContentWageListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentWageListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentWageListFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentWageList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentDuration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"durationText"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"level"}}]}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}}]}}]}}]} as unknown as DocumentNode<ContentWageListTableQuery, ContentWageListTableQueryVariables>;
 export const ContentRewardItemsFilterDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardItemsFilter"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItems"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentRewardItemsFilterQuery, ContentRewardItemsFilterQueryVariables>;
 export const CustomContentWageCalculateDialogQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CustomContentWageCalculateDialogQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItems"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<CustomContentWageCalculateDialogQueryQuery, CustomContentWageCalculateDialogQueryQueryVariables>;
@@ -743,10 +848,13 @@ export const MarketItemListTableDocument = {"kind":"Document","definitions":[{"k
 export const ContentCategoriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentCategoriesQuery, ContentCategoriesQueryVariables>;
 export const ContentDetailsDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentDetailsDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"quantity"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"level"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentRewardItems"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentDetailsDialogQuery, ContentDetailsDialogQueryVariables>;
 export const ContentDetailsDialogWageSectionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentDetailsDialogWageSection"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentWageFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDuration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"durationText"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"wage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}}]}}]}}]}}]} as unknown as DocumentNode<ContentDetailsDialogWageSectionQuery, ContentDetailsDialogWageSectionQueryVariables>;
+export const ContentGroupDetailsDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentGroupDetailsDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"contentIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentIds"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contents"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"gate"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentGroupDetailsDialogQuery, ContentGroupDetailsDialogQueryVariables>;
 export const ContentRewardReportDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardReportDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}},{"kind":"Field","name":{"kind":"Name","value":"userContentReward"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}}]}}]}}]}}]}}]} as unknown as DocumentNode<ContentRewardReportDialogQuery, ContentRewardReportDialogQueryVariables>;
 export const ContentRewardsReportDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentRewardsReport"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentRewardsReportInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardsReport"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentRewardsReportMutation, ContentRewardsReportMutationVariables>;
 export const UserContentDurationEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserContentDurationEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDuration"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"userContentDuration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]} as unknown as DocumentNode<UserContentDurationEditDialogQuery, UserContentDurationEditDialogQueryVariables>;
 export const UserContentDurationEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UserContentDurationEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserContentDurationEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userContentDurationEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<UserContentDurationEditMutation, UserContentDurationEditMutationVariables>;
+export const UserContentGroupDurationEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserContentGroupDurationEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"contentIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"ids"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDuration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userContentDuration"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"gate"}}]}}]}}]} as unknown as DocumentNode<UserContentGroupDurationEditDialogQuery, UserContentGroupDurationEditDialogQueryVariables>;
+export const UserContentDurationsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UserContentDurationsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserContentDurationsEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userContentDurationsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<UserContentDurationsEditMutation, UserContentDurationsEditMutationVariables>;
 export const UserContentRewardEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserContentRewardEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}},{"kind":"Field","name":{"kind":"Name","value":"userContentReward"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<UserContentRewardEditDialogQuery, UserContentRewardEditDialogQueryVariables>;
 export const UserContentRewardsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UserContentRewardsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserContentRewardsEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userContentRewardsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<UserContentRewardsEditMutation, UserContentRewardsEditMutationVariables>;
 export const UserContentSeeMoreRewardEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserContentSeeMoreRewardEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"userContentSeeMoreReward"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"quantity"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<UserContentSeeMoreRewardEditDialogQuery, UserContentSeeMoreRewardEditDialogQueryVariables>;

--- a/src/frontend/src/pages/content-wage-list/components/content-wage-list-filters.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/content-wage-list-filters.tsx
@@ -18,8 +18,14 @@ import { useContentWageListPage } from "~/pages/content-wage-list/content-wage-l
 import { ContentCategoryFilter } from "~/shared/content";
 
 export const ContentWageListFilters = () => {
-  const { contentCategoryId, keyword, setContentCategoryId, setKeyword } =
-    useContentWageListPage();
+  const {
+    contentCategoryId,
+    keyword,
+    setContentCategoryId,
+    setKeyword,
+    shouldMergeGate,
+    setShouldMergeGate,
+  } = useContentWageListPage();
 
   const handleCategoryChange = (value: number | null) => {
     setContentCategoryId(value || null);
@@ -53,6 +59,16 @@ export const ContentWageListFilters = () => {
               </Field>
               <Field label="귀속 재료 포함 여부">
                 <ContentIsBoundFilter />
+              </Field>
+              <Field label="관문 합쳐보기">
+                <SegmentedControl
+                  items={[
+                    { label: "합쳐보기", value: "true" },
+                    { label: "분리하기", value: "false" },
+                  ]}
+                  onValueChange={(e) => setShouldMergeGate(e.value === "true")}
+                  value={shouldMergeGate ? "true" : "false"}
+                />
               </Field>
             </Flex>
           </PopoverBody>

--- a/src/frontend/src/pages/content-wage-list/content-wage-list-page-context.tsx
+++ b/src/frontend/src/pages/content-wage-list/content-wage-list-page-context.tsx
@@ -30,6 +30,9 @@ type ContentWageListPageContextType = {
 
   includeContentRewardItemIds: number[];
   setIncludeContentRewardItemIds: Dispatch<SetStateAction<number[]>>;
+
+  shouldMergeGate?: boolean;
+  setShouldMergeGate: (value: boolean) => void;
 };
 
 const ContentWageListPageContext = createContext<
@@ -50,6 +53,7 @@ export const ContentWageListPageProvider = ({
   const [includeIsBound, setIncludeIsBound] = useState<boolean>(false);
   const [includeContentRewardItemIds, setIncludeContentRewardItemIds] =
     useState<number[]>(contentRewardItems.map((item) => item.id));
+  const [shouldMergeGate, setShouldMergeGate] = useState<boolean>(true);
 
   return (
     <ContentWageListPageContext.Provider
@@ -65,6 +69,8 @@ export const ContentWageListPageProvider = ({
         setIncludeIsBound,
         includeContentRewardItemIds,
         setIncludeContentRewardItemIds,
+        shouldMergeGate,
+        setShouldMergeGate,
       }}
     >
       {children}

--- a/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/content-group-wage-list-table.graphql
+++ b/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/content-group-wage-list-table.graphql
@@ -1,0 +1,17 @@
+query ContentGroupWageListTable($filter: ContentGroupWageListFilter) {
+  contentGroupWageList(filter: $filter) {
+    contentGroup {
+      contentCategory {
+        imageUrl
+        name
+      }
+      contentIds
+      durationText
+      level
+      name
+    }
+    goldAmountPerHour
+    goldAmountPerClear
+    krwAmountPerHour
+  }
+}

--- a/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/content-group-wage-list-table.tsx
+++ b/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/content-group-wage-list-table.tsx
@@ -5,17 +5,17 @@ import { useAuth } from "~/core/auth";
 import { Dialog, useDialog } from "~/core/dialog";
 import { FormatGold } from "~/core/format";
 import { useSafeQuery } from "~/core/graphql";
-import { ContentWageListTableDocument } from "~/core/graphql/generated";
+import { ContentGroupWageListTableDocument } from "~/core/graphql/generated";
 import { DataTable } from "~/core/table";
 import { LoginTooltip } from "~/core/tooltip";
 import { useContentWageListPage } from "~/pages/content-wage-list/content-wage-list-page-context";
 import {
-  ContentDetailsDialog,
-  UserContentDurationEditDialog,
+  ContentGroupDetailsDialog,
+  UserContentGroupDurationEditDialog,
 } from "~/shared/content";
 import { ItemNameWithImage } from "~/shared/item";
 
-export const ContentWageListTable = () => {
+export const ContentGroupWageListTable = () => {
   const { isAuthenticated } = useAuth();
   const {
     contentCategoryId,
@@ -26,9 +26,9 @@ export const ContentWageListTable = () => {
     shouldMergeGate,
   } = useContentWageListPage();
 
-  if (shouldMergeGate) return null;
+  if (!shouldMergeGate) return null;
 
-  const { data, refetch } = useSafeQuery(ContentWageListTableDocument, {
+  const { data, refetch } = useSafeQuery(ContentGroupWageListTableDocument, {
     variables: {
       filter: {
         contentCategoryId,
@@ -39,8 +39,9 @@ export const ContentWageListTable = () => {
       },
     },
   });
+
   const { onOpen, renderModal } = useDialog({
-    dialog: ContentDetailsDialog,
+    dialog: ContentGroupDetailsDialog,
   });
 
   return (
@@ -52,8 +53,8 @@ export const ContentWageListTable = () => {
             render({ data }) {
               return (
                 <ItemNameWithImage
-                  name={data.content.contentCategory.name}
-                  src={data.content.contentCategory.imageUrl}
+                  name={data.contentGroup.contentCategory.name}
+                  src={data.contentGroup.contentCategory.imageUrl}
                 />
               );
             },
@@ -61,14 +62,14 @@ export const ContentWageListTable = () => {
           {
             header: "레벨",
             render({ data }) {
-              return <>{data.content.level}</>;
+              return <>{data.contentGroup.level}</>;
             },
-            sortKey: "content.level",
+            sortKey: "contentGroup.level",
           },
           {
             header: "이름",
             render({ data }) {
-              return <>{data.content.displayName}</>;
+              return <>{data.contentGroup.name}</>;
             },
           },
           {
@@ -77,11 +78,11 @@ export const ContentWageListTable = () => {
             render({ data }) {
               return (
                 <Flex alignItems="center" display="inline-flex" gap={2}>
-                  <Text>{data.content.durationText}</Text>
+                  <Text>{data.contentGroup.durationText}</Text>
                   <Dialog.Trigger
-                    dialog={UserContentDurationEditDialog}
+                    dialog={UserContentGroupDurationEditDialog}
                     dialogProps={{
-                      contentDurationId: data.content.contentDuration.id,
+                      contentIds: data.contentGroup.contentIds,
                       onComplete: refetch,
                     }}
                   >
@@ -133,11 +134,11 @@ export const ContentWageListTable = () => {
         getRowProps={({ data }) => ({
           onClick: () =>
             onOpen({
-              contentId: data.content.id,
+              contentIds: data.contentGroup.contentIds,
               onComplete: refetch,
             }),
         })}
-        rows={data.contentWageList.map((data) => ({
+        rows={data.contentGroupWageList.map((data) => ({
           data,
         }))}
       />

--- a/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/content-wage-table-tab.tsx
+++ b/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/content-wage-table-tab.tsx
@@ -18,6 +18,7 @@ import { ContentWageListTable } from "./components/content-wage-list-table";
 import { GoldExchangeRateSettingDialog } from "./components/gold-exchange-rate-setting-dialog";
 import { ContentWageListFilters } from "../../components";
 import { ContentWageListPageProvider } from "../../content-wage-list-page-context";
+import { ContentGroupWageListTable } from "./components/content-group-wage-list-table";
 import { CustomContentWageCalculateDialog } from "./components/custom-content-wage-calculate-dialog";
 
 export const ContentWageTableTab = () => {
@@ -59,6 +60,9 @@ export const ContentWageTableTab = () => {
         </Flex>
         <Suspense fallback={<TableSkeleton line={30} />}>
           <ContentWageListTable />
+        </Suspense>
+        <Suspense fallback={<TableSkeleton line={30} />}>
+          <ContentGroupWageListTable />
         </Suspense>
       </ContentWageListPageProvider>
     </Section>

--- a/src/frontend/src/shared/content/content-group-details-dialog.graphql
+++ b/src/frontend/src/shared/content/content-group-details-dialog.graphql
@@ -1,0 +1,9 @@
+query ContentGroupDetailsDialog($contentIds: [Int!]!) {
+  contentGroup(filter: { contentIds: $contentIds }) {
+    contents {
+      gate
+      id
+    }
+    name
+  }
+}

--- a/src/frontend/src/shared/content/content-group-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-group-details-dialog.tsx
@@ -1,0 +1,394 @@
+import { Flex, IconButton, Text } from "@chakra-ui/react";
+import { Suspense, useState } from "react";
+import { IoIosSettings } from "react-icons/io";
+import { IoFilter } from "react-icons/io5";
+import { LuPencilLine } from "react-icons/lu";
+
+import { useAuth } from "~/core/auth";
+import { Button } from "~/core/chakra-components/ui/button";
+import { Field } from "~/core/chakra-components/ui/field";
+import {
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "~/core/chakra-components/ui/popover";
+import { SegmentedControl } from "~/core/chakra-components/ui/segmented-control";
+import { DataGrid } from "~/core/data-grid";
+import { Dialog, DialogProps } from "~/core/dialog";
+import { DialogCloseButton } from "~/core/dialog/dialog-close-button";
+import { useSafeQuery } from "~/core/graphql";
+import {
+  ContentDetailsDialogDocument,
+  ContentDetailsDialogWageSectionDocument,
+  ContentGroupDetailsDialogDocument,
+} from "~/core/graphql/generated";
+import { TableSkeleton } from "~/core/loader";
+import { Section } from "~/core/section";
+import { MultiSelect } from "~/core/select";
+import { LoginTooltip } from "~/core/tooltip";
+
+import { ItemNameWithImage } from "../item";
+import { UserContentDurationEditDialog } from "./user-content-duration-edit-dialog";
+import { UserContentRewardEditDialog } from "./user-content-reward-edit-dialog";
+import { UserContentSeeMoreRewardEditDialog } from "./user-content-see-more-reward-edit-dialog";
+
+type ContentGroupDetailsDialogProps = DialogProps & {
+  contentIds: number[];
+  onComplete: () => void;
+};
+
+export const ContentGroupDetailsDialog = ({
+  contentIds,
+  onClose,
+  onComplete,
+  open,
+}: ContentGroupDetailsDialogProps) => {
+  const { data } = useSafeQuery(ContentGroupDetailsDialogDocument, {
+    variables: {
+      contentIds,
+    },
+  });
+
+  return (
+    <Dialog
+      onClose={() => {
+        onClose();
+        onComplete();
+      }}
+      open={open}
+      size="xl"
+    >
+      <Dialog.Content>
+        <Dialog.Header>컨텐츠 상세 정보</Dialog.Header>
+        <Dialog.Body>
+          <Flex direction="column" gap={4}>
+            {data.contentGroup.contents.length > 1 ? (
+              data.contentGroup.contents.map((content) => (
+                <Section key={content.id} title={`${content.gate}관문`}>
+                  <ContentGroupSection contentId={content.id} />
+                </Section>
+              ))
+            ) : (
+              <ContentGroupSection
+                contentId={data.contentGroup.contents[0].id}
+              />
+            )}
+          </Flex>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <DialogCloseButton />
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+};
+
+const ContentGroupSection = ({ contentId }: { contentId: number }) => {
+  const { data, refetch } = useSafeQuery(ContentDetailsDialogDocument, {
+    variables: {
+      contentId,
+    },
+  });
+  const { isAuthenticated } = useAuth();
+
+  const basicInfoItems = [
+    {
+      label: "종류",
+      value: (
+        <ItemNameWithImage
+          name={data.content.contentCategory.name}
+          src={data.content.contentCategory.imageUrl}
+        />
+      ),
+    },
+    { label: "레벨", value: data.content.level },
+    { label: "이름", value: data.content.displayName },
+  ];
+
+  const contentRewardsItems = data.content.contentRewards.map(
+    (contentReward) => ({
+      label: (
+        <ItemNameWithImage
+          name={contentReward.contentRewardItem.name}
+          reverse
+          src={contentReward.contentRewardItem.imageUrl}
+        />
+      ),
+      value: contentReward.averageQuantity,
+    })
+  );
+
+  const contentSeeMoreRewardsItems = data.content.contentSeeMoreRewards.map(
+    (contentSeeMoreReward) => ({
+      label: (
+        <ItemNameWithImage
+          name={contentSeeMoreReward.contentRewardItem.name}
+          reverse
+          src={contentSeeMoreReward.contentRewardItem.imageUrl}
+        />
+      ),
+      value: contentSeeMoreReward.quantity,
+    })
+  );
+
+  return (
+    <Flex direction="column" gap={4}>
+      <Section title="기본 정보">
+        <DataGrid items={basicInfoItems} />
+      </Section>
+      <ContentWageSection
+        contentId={contentId}
+        contentRewardItems={data.contentRewardItems}
+      />
+      <Section
+        title={
+          <Flex alignItems="center" gap={2}>
+            <Text>보상 정보</Text>
+            <Dialog.Trigger
+              dialog={UserContentRewardEditDialog}
+              dialogProps={{
+                contentId,
+                onComplete: refetch,
+              }}
+            >
+              <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
+                <IconButton
+                  disabled={!isAuthenticated}
+                  size="2xs"
+                  variant="surface"
+                >
+                  <IoIosSettings />
+                </IconButton>
+              </LoginTooltip>
+            </Dialog.Trigger>
+          </Flex>
+        }
+      >
+        <DataGrid items={contentRewardsItems} />
+      </Section>
+      {contentSeeMoreRewardsItems.length > 0 && (
+        <Section
+          title={
+            <Flex alignItems="center" gap={2}>
+              <Text>더보기 보상 정보</Text>
+              <Dialog.Trigger
+                dialog={UserContentSeeMoreRewardEditDialog}
+                dialogProps={{
+                  contentId,
+                  onComplete: refetch,
+                }}
+              >
+                <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
+                  <IconButton
+                    disabled={!isAuthenticated}
+                    size="2xs"
+                    variant="surface"
+                  >
+                    <IoIosSettings />
+                  </IconButton>
+                </LoginTooltip>
+              </Dialog.Trigger>
+            </Flex>
+          }
+        >
+          <DataGrid items={contentSeeMoreRewardsItems} />
+        </Section>
+      )}
+    </Flex>
+  );
+};
+
+const ContentWageSection = ({
+  contentId,
+  contentRewardItems,
+}: {
+  contentId: number;
+  contentRewardItems: { id: number; name: string }[];
+}) => {
+  const [includeIsSeeMore, setIncludeIsSeeMore] = useState(false);
+  const [includeIsBound, setIncludeIsBound] = useState(false);
+  const [includeContentRewardItemIds, setIncludeContentRewardItemIds] =
+    useState<number[]>(contentRewardItems.map(({ id }) => id));
+
+  return (
+    <Section
+      title={
+        <Flex alignItems="center" gap={4}>
+          시급 정보{" "}
+          <PopoverRoot positioning={{ placement: "right-end" }}>
+            <PopoverTrigger asChild>
+              <Button size="xs" variant="outline">
+                <IoFilter />
+                필터
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent portalled={false}>
+              <PopoverArrow />
+              <PopoverBody>
+                <Flex direction="column" gap={4}>
+                  <Field label="컨텐츠 보상 종류" w="auto">
+                    <ContentRewardItemsFilter
+                      contentRewardItems={contentRewardItems}
+                      includeContentRewardItemIds={includeContentRewardItemIds}
+                      setIncludeContentRewardItemIds={
+                        setIncludeContentRewardItemIds
+                      }
+                    />
+                  </Field>
+                  <Field label="더보기 포함 여부" w="auto">
+                    <ContentSeeMoreFilter
+                      includeIsSeeMore={includeIsSeeMore}
+                      setIncludeIsSeeMore={setIncludeIsSeeMore}
+                    />
+                  </Field>
+                  <Field label="귀속 재료 포함 여부" w="auto">
+                    <ContentIsBoundFilter
+                      includeIsBound={includeIsBound}
+                      setIncludeIsBound={setIncludeIsBound}
+                    />
+                  </Field>
+                </Flex>
+              </PopoverBody>
+            </PopoverContent>
+          </PopoverRoot>
+        </Flex>
+      }
+    >
+      <Suspense fallback={<TableSkeleton line={1} />}>
+        <ContentWageSectionDataGrid
+          contentId={contentId}
+          includeContentRewardItemIds={includeContentRewardItemIds}
+          includeIsBound={includeIsBound}
+          includeIsSeeMore={includeIsSeeMore}
+        />
+      </Suspense>
+    </Section>
+  );
+};
+
+const ContentWageSectionDataGrid = ({
+  contentId,
+  includeIsSeeMore,
+  includeIsBound,
+  includeContentRewardItemIds,
+}: {
+  contentId: number;
+  includeIsSeeMore: boolean;
+  includeIsBound: boolean;
+  includeContentRewardItemIds: number[];
+}) => {
+  const { isAuthenticated } = useAuth();
+  const { data, refetch } = useSafeQuery(
+    ContentDetailsDialogWageSectionDocument,
+    {
+      variables: {
+        contentId,
+        filter: {
+          includeIsSeeMore,
+          includeIsBound,
+          includeContentRewardItemIds,
+        },
+      },
+    }
+  );
+
+  const wageItems = [
+    {
+      label: "소요 시간",
+      value: (
+        <Flex alignItems="center" gap={2}>
+          <Text>{data.content.durationText}</Text>
+          <Dialog.Trigger
+            dialog={UserContentDurationEditDialog}
+            dialogProps={{
+              contentDurationId: data.content.contentDuration.id,
+              onComplete: refetch,
+            }}
+          >
+            <LoginTooltip>
+              <IconButton
+                disabled={!isAuthenticated}
+                h={4}
+                minW={4}
+                p={0}
+                size="2xs"
+                variant="ghost"
+              >
+                <LuPencilLine />
+              </IconButton>
+            </LoginTooltip>
+          </Dialog.Trigger>
+        </Flex>
+      ),
+    },
+    { label: "시급(원)", value: data.content.wage.krwAmountPerHour },
+    { label: "시급(골드)", value: data.content.wage.goldAmountPerHour },
+    { label: "1수당 골드", value: data.content.wage.goldAmountPerClear },
+  ];
+
+  return <DataGrid items={wageItems} />;
+};
+
+const ContentSeeMoreFilter = ({
+  includeIsSeeMore,
+  setIncludeIsSeeMore,
+}: {
+  includeIsSeeMore: boolean;
+  setIncludeIsSeeMore: (value: boolean) => void;
+}) => {
+  return (
+    <SegmentedControl
+      items={[
+        { label: "미포함", value: "false" },
+        { label: "포함", value: "true" },
+      ]}
+      onValueChange={(e) => setIncludeIsSeeMore(e.value === "true")}
+      value={includeIsSeeMore ? "true" : "false"}
+    />
+  );
+};
+
+const ContentIsBoundFilter = ({
+  includeIsBound,
+  setIncludeIsBound,
+}: {
+  includeIsBound: boolean;
+  setIncludeIsBound: (value: boolean) => void;
+}) => {
+  return (
+    <SegmentedControl
+      items={[
+        { label: "미포함", value: "false" },
+        { label: "포함", value: "true" },
+      ]}
+      onValueChange={(e) => setIncludeIsBound(e.value === "true")}
+      value={includeIsBound ? "true" : "false"}
+    />
+  );
+};
+
+const ContentRewardItemsFilter = ({
+  contentRewardItems,
+  includeContentRewardItemIds,
+  setIncludeContentRewardItemIds,
+}: {
+  contentRewardItems: { id: number; name: string }[];
+  includeContentRewardItemIds: number[];
+  setIncludeContentRewardItemIds: (value: number[]) => void;
+}) => {
+  const items = contentRewardItems.map(({ id, name }) => ({
+    label: name,
+    value: id,
+  }));
+
+  return (
+    <MultiSelect
+      items={items}
+      onChange={setIncludeContentRewardItemIds}
+      placeholder="보상 아이템 선택"
+      value={includeContentRewardItemIds}
+    />
+  );
+};

--- a/src/frontend/src/shared/content/index.tsx
+++ b/src/frontend/src/shared/content/index.tsx
@@ -1,5 +1,7 @@
 export * from "./content-category-filter";
 export * from "./content-details-dialog";
+export * from "./content-group-details-dialog";
 export * from "./user-content-duration-edit-dialog";
+export * from "./user-content-group-duration-edit-dialog";
 export * from "./user-content-reward-edit-dialog";
 export * from "./user-content-see-more-reward-edit-dialog";

--- a/src/frontend/src/shared/content/user-content-group-duration-edit-dialog.graphql
+++ b/src/frontend/src/shared/content/user-content-group-duration-edit-dialog.graphql
@@ -1,0 +1,20 @@
+query UserContentGroupDurationEditDialog($ids: [Int!]!) {
+  contentGroup(filter: { contentIds: $ids }) {
+    name
+  }
+  contents(filter: { ids: $ids }) {
+    contentDuration {
+      userContentDuration {
+        id
+        value
+      }
+    }
+    gate
+  }
+}
+
+mutation UserContentDurationsEdit($input: UserContentDurationsEditInput!) {
+  userContentDurationsEdit(input: $input) {
+    ok
+  }
+}

--- a/src/frontend/src/shared/content/user-content-group-duration-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/user-content-group-duration-edit-dialog.tsx
@@ -1,0 +1,111 @@
+import { Flex, Text } from "@chakra-ui/react";
+
+import { toaster } from "~/core/chakra-components/ui/toaster";
+import { Dialog, DialogProps } from "~/core/dialog";
+import { Form, z } from "~/core/form";
+import { useSafeQuery } from "~/core/graphql";
+import {
+  UserContentDurationsEditDocument,
+  UserContentDurationsEditInput,
+  UserContentDurationsEditMutation,
+  UserContentGroupDurationEditDialogDocument,
+} from "~/core/graphql/generated";
+
+const schema = z.object({
+  contentDurations: z.array(
+    z.object({
+      id: z.number(),
+      minutes: z.number().int32().min(0),
+      seconds: z.number().int32().min(0).max(59),
+    })
+  ),
+});
+
+type UserContentGroupDurationEditDialogProps = {
+  contentIds: number[];
+  onComplete: () => void;
+};
+
+export const UserContentGroupDurationEditDialog = ({
+  contentIds,
+  onComplete,
+  ...dialogProps
+}: DialogProps & UserContentGroupDurationEditDialogProps) => {
+  const { data } = useSafeQuery(UserContentGroupDurationEditDialogDocument, {
+    variables: {
+      ids: contentIds,
+    },
+  });
+
+  return (
+    <Dialog {...dialogProps}>
+      <Form.Mutation<
+        UserContentDurationsEditInput,
+        UserContentDurationsEditMutation
+      >
+        defaultValues={{
+          contentDurations: data.contents.map(({ contentDuration }) => {
+            const totalSeconds = contentDuration.userContentDuration.value;
+            const minutes = Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+
+            return {
+              id: contentDuration.userContentDuration.id,
+              minutes: minutes,
+              seconds: seconds,
+            };
+          }),
+        }}
+        mutation={UserContentDurationsEditDocument}
+        onComplete={() => {
+          dialogProps.onClose();
+          onComplete();
+          toaster.create({
+            title: "컨텐츠 소요시간이 수정되었습니다.",
+            type: "success",
+          });
+        }}
+        schema={schema}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            {data.contentGroup.name} - 소요시간 수정
+          </Dialog.Header>
+          <Dialog.Body>
+            <Form.Body>
+              <Flex direction="column" gap={4}>
+                {data.contents.map(({ gate }, index) => (
+                  <Flex direction="column" gap={1}>
+                    {data.contents.length > 1 && (
+                      <Text fontSize="xs">{gate}관문</Text>
+                    )}
+                    <Flex gap={4} paddingLeft={1}>
+                      <Form.Field
+                        label="분"
+                        name={`contentDurations.${index}.minutes`}
+                      >
+                        <Form.NumberInput min={0} />
+                      </Form.Field>
+                      <Form.Field
+                        label="초"
+                        name={`contentDurations.${index}.seconds`}
+                      >
+                        <Form.NumberInput max={59} min={0} />
+                      </Form.Field>
+                    </Flex>
+                  </Flex>
+                ))}
+              </Flex>
+            </Form.Body>
+          </Dialog.Body>
+          <Dialog.Footer>
+            <Form.Footer>
+              <Dialog.CloseButton />
+              <Form.SubmitButton />
+            </Form.Footer>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Form.Mutation>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
- 기존 사용자는 "카제로스 레이드"와 같은 컨텐츠를 일반적으로 관문을 나눠서 진행하지 않기 때문에, 모든 관문을 합친 통합 시급을 보고 싶은 니즈가 있음.
- 데이터 구조 자체를 수정하는 것은 불필요한 복잡도를 증가시키기 때문에, content-group 이라는 view 개념을 만들어서 name이 같고 gate가 다른 여러 컨텐츠를 묶은 개념을 추가시킴.
- 시급 페이지에서 필터를 통해 관문을 합쳐볼지 분리하여 볼지 선택할 수 있으며, 기본값으로 합쳐보기를 적용시킴.
- 소요시간 수정 및 컨텐츠 상세 다이얼로그는 묶여있던 그룹을 풀어서 여러 컨텐츠에 대해 bulk update 가능한 형태로 추가함.

AS-IS
![image](https://github.com/user-attachments/assets/5a5cb057-0ec8-4dbf-9a90-0dc00a230e3e)

TO-BE
![image](https://github.com/user-attachments/assets/00127eeb-225c-47fb-8325-d969ad78aa4a)
![image](https://github.com/user-attachments/assets/4e6612c7-9765-42c6-a0cb-0033f029635e)
![image](https://github.com/user-attachments/assets/c3d9cc0d-9023-443c-80df-c4399add2857)
