### PR TITLE
컨텐츠 보상 수정 시 모든 아이템 보상 설정 가능하도록 수정

### DIFF
--- a/src/backend/prisma/migrations/20250626121453_create_content_reward_data/migration.sql
+++ b/src/backend/prisma/migrations/20250626121453_create_content_reward_data/migration.sql
@@ -1,0 +1,86 @@
+-- AlterTable
+ALTER TABLE "content_reward" ALTER COLUMN "default_average_quantity" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "content_see_more_reward" ALTER COLUMN "quantity" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "user_content_reward" ADD COLUMN "is_sellable" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "average_quantity" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "user_content_see_more_reward" ALTER COLUMN "quantity" SET DEFAULT 0;
+
+INSERT INTO "content_reward" (
+    "content_id", 
+    "content_reward_item_id", 
+    "created_at", 
+    "updated_at"
+)
+SELECT 
+    c.id,
+    cri.id,
+    NOW(),
+    NOW()
+FROM "content" c
+CROSS JOIN "content_reward_item" cri
+ON CONFLICT ("content_id", "content_reward_item_id") DO NOTHING;
+
+UPDATE "user_content_reward" 
+SET "is_sellable" = cr."is_sellable",
+    "updated_at" = NOW()
+FROM "content_reward" cr
+WHERE "user_content_reward"."content_reward_id" = cr.id;
+
+INSERT INTO "user_content_reward" (
+    "user_id",
+    "content_reward_id",
+    "created_at",
+    "updated_at"
+)
+SELECT 
+    u.id,
+    cr.id,
+    NOW(),
+    NOW()
+FROM "user" u
+CROSS JOIN "content_reward" cr
+ON CONFLICT ("user_id", "content_reward_id") DO NOTHING;
+
+INSERT INTO "content_see_more_reward" (
+    "content_id",
+    "content_reward_item_id",
+    "created_at",
+    "updated_at"
+)
+SELECT 
+    c.id,
+    cri.id,
+    NOW(),
+    NOW()
+FROM "content" c
+CROSS JOIN "content_reward_item" cri
+WHERE EXISTS (
+    SELECT 1 FROM "content_see_more_reward" existing_csmr 
+    WHERE existing_csmr."content_id" = c.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM "content_see_more_reward" csmr 
+    WHERE csmr."content_id" = c.id 
+    AND csmr."content_reward_item_id" = cri.id
+);
+
+INSERT INTO "user_content_see_more_reward" (
+    "user_id",
+    "content_see_more_reward_id",
+    "created_at",
+    "updated_at"
+)
+SELECT 
+    u.id,
+    csmr.id,
+    NOW(),
+    NOW()
+FROM "user" u
+CROSS JOIN "content_see_more_reward" csmr
+ON CONFLICT ("user_id", "content_see_more_reward_id") DO NOTHING;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -115,7 +115,7 @@ model ContentReward {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  defaultAverageQuantity Decimal @map("default_average_quantity")
+  defaultAverageQuantity Decimal @default(0) @map("default_average_quantity")
   isSellable             Boolean @default(false) @map("is_sellable")
 
   // Relations
@@ -154,7 +154,7 @@ model ContentSeeMoreReward {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  quantity Decimal
+  quantity Decimal @default(0)
 
   // Relations
   contentId                 Int                        @map("content_id")
@@ -304,8 +304,9 @@ model UserContentReward {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  averageQuantity Decimal @map("average_quantity")
+  averageQuantity Decimal @default(0) @map("average_quantity")
   isEdited        Boolean @default(false) @map("is_edited")
+  isSellable      Boolean @default(false) @map("is_sellable")
 
   // Relations
   contentRewardId Int           @map("content_reward_id")
@@ -323,7 +324,7 @@ model UserContentSeeMoreReward {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   isEdited Boolean @default(false) @map("is_edited")
-  quantity Decimal
+  quantity Decimal @default(0)
 
   // Relations
   contentSeeMoreRewardId Int                  @map("content_see_more_reward_id")

--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -352,6 +352,7 @@ type UserContentReward {
   contentRewardId: Int!
   createdAt: DateTime!
   id: Int!
+  isSellable: Boolean!
   updatedAt: DateTime!
   userId: Int!
 }
@@ -359,6 +360,7 @@ type UserContentReward {
 input UserContentRewardEditInput {
   averageQuantity: Float!
   id: Int!
+  isSellable: Boolean!
 }
 
 type UserContentRewardItem {

--- a/src/backend/src/content/mutation/user-content-rewards-edit.mutation.ts
+++ b/src/backend/src/content/mutation/user-content-rewards-edit.mutation.ts
@@ -22,6 +22,9 @@ class UserContentRewardEditInput {
 
   @Field(() => Float)
   averageQuantity: number;
+
+  @Field(() => Boolean)
+  isSellable: boolean;
 }
 
 @InputType()
@@ -62,10 +65,10 @@ export class UserContentRewardsEditMutation {
       }
 
       await Promise.all(
-        input.userContentRewards.map(({ id, averageQuantity }) =>
+        input.userContentRewards.map(({ id, averageQuantity, isSellable }) =>
           tx.userContentReward.update({
             where: { id },
-            data: { averageQuantity, isEdited: true },
+            data: { averageQuantity, isEdited: true, isSellable },
           }),
         ),
       );
@@ -98,7 +101,7 @@ export class UserContentRewardsEditMutation {
     tx: Prisma.TransactionClient,
   ) {
     await Promise.all(
-      userContentRewards.map(async ({ id, averageQuantity }) => {
+      userContentRewards.map(async ({ id, averageQuantity, isSellable }) => {
         const userContentReward = await tx.userContentReward.findUniqueOrThrow({
           where: { id },
           include: {
@@ -113,6 +116,7 @@ export class UserContentRewardsEditMutation {
           },
           data: {
             averageQuantity,
+            isSellable,
           },
         });
 
@@ -122,6 +126,7 @@ export class UserContentRewardsEditMutation {
           },
           data: {
             defaultAverageQuantity: averageQuantity,
+            isSellable,
           },
         });
       }),

--- a/src/backend/src/content/object/content-reward.object.ts
+++ b/src/backend/src/content/object/content-reward.object.ts
@@ -5,7 +5,4 @@ import { BaseObject } from 'src/common/object/base.object';
 export class ContentReward extends BaseObject {
   @Field()
   contentRewardItemId: number;
-
-  @Field(() => Boolean)
-  isSellable: boolean;
 }

--- a/src/backend/src/content/object/content-reward.resolver.ts
+++ b/src/backend/src/content/object/content-reward.resolver.ts
@@ -32,6 +32,13 @@ export class ContentRewardResolver {
     );
   }
 
+  @ResolveField(() => Boolean)
+  async isSellable(@Parent() contentReward: ContentReward) {
+    return await this.userContentService.getContentRewardIsSellable(
+      contentReward.id,
+    );
+  }
+
   @UseGuards(AuthGuard)
   @ResolveField(() => UserContentReward)
   async userContentReward(

--- a/src/backend/src/content/object/user-content-reward.object.ts
+++ b/src/backend/src/content/object/user-content-reward.object.ts
@@ -10,5 +10,8 @@ export class UserContentReward extends BaseObject {
   contentRewardId: number;
 
   @Field()
+  isSellable: boolean;
+
+  @Field()
   userId: number;
 }

--- a/src/backend/src/user/service/user-content.service.spec.ts
+++ b/src/backend/src/user/service/user-content.service.spec.ts
@@ -504,11 +504,13 @@ describe('UserContentService', () => {
             userId: user.id,
             contentRewardId: contentReward1.id,
             averageQuantity: userAverageQuantity1,
+            isSellable: true,
           },
           {
             userId: user.id,
             contentRewardId: contentReward2.id,
             averageQuantity: userAverageQuantity2,
+            isSellable: false,
           },
         ],
       });

--- a/src/backend/src/user/service/user-seed.service.ts
+++ b/src/backend/src/user/service/user-seed.service.ts
@@ -45,9 +45,10 @@ export class UserSeedService {
 
     await tx.userContentReward.createMany({
       data: defaultRewards.map(
-        ({ id, defaultAverageQuantity: averageQuantity }) => ({
+        ({ id, defaultAverageQuantity: averageQuantity, isSellable }) => ({
           contentRewardId: id,
           averageQuantity,
+          isSellable,
           userId,
           createdAt,
         }),

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -503,6 +503,7 @@ export type UserContentReward = {
   contentRewardId: Scalars['Int']['output'];
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['Int']['output'];
+  isSellable: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
   userId: Scalars['Int']['output'];
 };
@@ -510,6 +511,7 @@ export type UserContentReward = {
 export type UserContentRewardEditInput = {
   averageQuantity: Scalars['Float']['input'];
   id: Scalars['Int']['input'];
+  isSellable: Scalars['Boolean']['input'];
 };
 
 export type UserContentRewardItem = {

--- a/src/frontend/src/pages/content-reward-list/tabs/content-reward-list-table-tab/components/content-reward-list-table.tsx
+++ b/src/frontend/src/pages/content-reward-list/tabs/content-reward-list-table-tab/components/content-reward-list-table.tsx
@@ -131,7 +131,7 @@ export const ContentRewardListTable = () => {
                   (reward) => reward.contentRewardItem.name === name
                 );
 
-                if (!reward) return <>-</>;
+                if (!reward || reward.averageQuantity === 0) return <>-</>;
 
                 const isGold = name === "골드";
 

--- a/src/frontend/src/shared/content/content-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-details-dialog.tsx
@@ -74,7 +74,7 @@ export const ContentDetailsDialog = ({
           src={contentReward.contentRewardItem.imageUrl}
         />
       ),
-      value: contentReward.averageQuantity,
+      value: contentReward.averageQuantity || "-",
     })
   );
 

--- a/src/frontend/src/shared/content/user-content-reward-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/user-content-reward-edit-dialog.tsx
@@ -1,5 +1,6 @@
-import { Link } from "@chakra-ui/react";
+import { Link, NativeSelect } from "@chakra-ui/react";
 
+import { InputGroup } from "~/core/chakra-components/ui/input-group";
 import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
@@ -18,6 +19,7 @@ const schema = z.object({
     z.object({
       id: z.number(),
       averageQuantity: z.number(),
+      isSellable: z.boolean(),
     })
   ),
   isReportable: z.boolean(),
@@ -49,6 +51,7 @@ export const UserContentRewardEditDialog = ({
           userContentRewards: data.content.contentRewards.map((reward) => ({
             id: reward.userContentReward.id,
             averageQuantity: reward.userContentReward.averageQuantity,
+            isSellable: reward.isSellable,
           })),
           isReportable: true,
         }}
@@ -63,39 +66,90 @@ export const UserContentRewardEditDialog = ({
         }}
         schema={schema}
       >
-        <Dialog.Content>
-          <Dialog.Header>{data.content.displayName} - 보상 수정</Dialog.Header>
-          <Dialog.Body>
-            <Form.Body>
-              {data.content.contentRewards.map((reward, index) => (
-                <Form.Field
-                  key={reward.userContentReward.id}
-                  label={reward.contentRewardItem.name}
-                  name={`userContentRewards.${index}.averageQuantity`}
-                >
-                  <Form.NumberInput />
+        {({ setValue, watch }) => (
+          <Dialog.Content>
+            <Dialog.Header>
+              {data.content.displayName} - 보상 수정
+            </Dialog.Header>
+            <Dialog.Body>
+              <Form.Body>
+                {data.content.contentRewards.map((reward, index) => (
+                  <Form.Field
+                    key={reward.userContentReward.id}
+                    label={reward.contentRewardItem.name}
+                    name={`userContentRewards.${index}.averageQuantity`}
+                  >
+                    <InputGroup
+                      endElement={
+                        <NativeSelect.Root
+                          me="-1"
+                          size="xs"
+                          variant="plain"
+                          width="auto"
+                        >
+                          <NativeSelect.Field
+                            fontSize="sm"
+                            onChange={(e) => {
+                              setValue(
+                                `userContentRewards.${index}.isSellable`,
+                                e.target.value === "true"
+                              );
+                            }}
+                            value={
+                              watch(`userContentRewards.${index}.isSellable`)
+                                ? "true"
+                                : "false"
+                            }
+                          >
+                            <option style={{ color: "black" }} value="true">
+                              거래 가능
+                            </option>
+                            <option style={{ color: "black" }} value="false">
+                              귀속
+                            </option>
+                          </NativeSelect.Field>
+                          <NativeSelect.Indicator />
+                        </NativeSelect.Root>
+                      }
+                      w="full"
+                    >
+                      <Form.Input
+                        css={{
+                          "&::-webkit-outer-spin-button, &::-webkit-inner-spin-button":
+                            {
+                              "-webkit-appearance": "none",
+                              margin: 0,
+                            },
+                          "&[type=number]": {
+                            "-moz-appearance": "textfield",
+                          },
+                        }}
+                        type="number"
+                      />
+                    </InputGroup>
+                  </Form.Field>
+                ))}
+                <Form.Field name="isReportable" optional>
+                  <Form.Checkbox>저장 후 데이터 제보</Form.Checkbox>
                 </Form.Field>
-              ))}
-              <Form.Field name="isReportable" optional>
-                <Form.Checkbox>저장 후 데이터 제보</Form.Checkbox>
-              </Form.Field>
-              <Dialog.Trigger
-                dialog={ContentRewardReportDialog}
-                dialogProps={{
-                  contentId,
-                }}
-              >
-                <Link variant="underline">저장없이 제보만하기</Link>
-              </Dialog.Trigger>
-            </Form.Body>
-          </Dialog.Body>
-          <Dialog.Footer>
-            <Form.Footer>
-              <Dialog.CloseButton />
-              <Form.SubmitButton />
-            </Form.Footer>
-          </Dialog.Footer>
-        </Dialog.Content>
+                <Dialog.Trigger
+                  dialog={ContentRewardReportDialog}
+                  dialogProps={{
+                    contentId,
+                  }}
+                >
+                  <Link variant="underline">저장없이 제보만하기</Link>
+                </Dialog.Trigger>
+              </Form.Body>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Form.Footer>
+                <Dialog.CloseButton />
+                <Form.SubmitButton />
+              </Form.Footer>
+            </Dialog.Footer>
+          </Dialog.Content>
+        )}
       </Form.Mutation>
     </Dialog>
   );


### PR DESCRIPTION
- 이슈 해결을 위해 모든 컨텐츠 보상의 수량 정보에 default 값을 부여함(0개).
- 또한 서버 설정을 거스르는 정보 수정이 가능하기 때문에 귀속 여부까지 설정 가능하도록 자유도를 부여함.
- 기존에 이미 존재하던 유저 커스텀 보상은 서버의 귀속 여부 값을 상속받도록 함.
- 이제 수정 모달에서는 모든 보상을 수정할 수 있도록 하고, 귀속 여부 설정이 가능함.
- 귀속 여부가 유저 커스텀 테이블에도 추가되기 때문에, 시급 계산시에도 귀속 여부 체크를 유저 테이블을 함께 고려하도록 함.
- 보상 테이블 및 상세 모달에서 0개인 경우는 편의 상 "-" 표시하도록 함(가시성 문제).