### PR TITLE
테이블 셀 내용이 길 때 셀 영역을 넘어가는 문제 수정 #126

### DIFF
--- a/src/frontend/src/core/table/data-table.tsx
+++ b/src/frontend/src/core/table/data-table.tsx
@@ -198,58 +198,60 @@ export const DataTable = <T,>({
   );
 
   return (
-    <Table.ScrollArea maxHeight="4xl" {...rest}>
-      <Table.Root interactive={isInteractive} showColumnBorder stickyHeader>
-        <Table.Header>
-          <Table.Row>
-            {hasData &&
-              columns.map((column, index) => (
-                <Table.ColumnHeader
-                  key={index}
-                  {...(column.align && { textAlign: column.align })}
-                  {...(column.width && { width: column.width })}
-                >
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    gap={1}
-                    justifyContent={column.align}
-                    whiteSpace="nowrap"
-                  >
-                    {column.header}
-                    {column.sortKey && (
-                      <SortControl
-                        currentState={
-                          currentSortKey === column.sortKey ? sortOrder : null
-                        }
-                        onClick={() => handleSort(column)}
-                      />
-                    )}
-                  </Box>
-                </Table.ColumnHeader>
-              ))}
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {!hasData ? (
+    <>
+      <Table.ScrollArea maxHeight="4xl" {...rest}>
+        <Table.Root interactive={isInteractive} showColumnBorder stickyHeader>
+          <Table.Header>
             <Table.Row>
-              <Table.Cell colSpan={columns.length}>
-                <EmptyState.Root size="lg">
-                  <EmptyState.Content py={24}>
-                    <EmptyState.Description>
-                      조회된 데이터가 없습니다
-                    </EmptyState.Description>
-                  </EmptyState.Content>
-                </EmptyState.Root>
-              </Table.Cell>
+              {hasData &&
+                columns.map((column, index) => (
+                  <Table.ColumnHeader
+                    key={index}
+                    {...(column.align && { textAlign: column.align })}
+                    {...(column.width && { width: column.width })}
+                  >
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      gap={1}
+                      justifyContent={column.align}
+                      whiteSpace="nowrap"
+                    >
+                      {column.header}
+                      {column.sortKey && (
+                        <SortControl
+                          currentState={
+                            currentSortKey === column.sortKey ? sortOrder : null
+                          }
+                          onClick={() => handleSort(column)}
+                        />
+                      )}
+                    </Box>
+                  </Table.ColumnHeader>
+                ))}
             </Table.Row>
-          ) : pagination ? (
-            currentData.map((row, index) => renderRow(row, index))
-          ) : (
-            displayRows.map((row, index) => renderRow(row, index))
-          )}
-        </Table.Body>
-      </Table.Root>
+          </Table.Header>
+          <Table.Body>
+            {!hasData ? (
+              <Table.Row>
+                <Table.Cell colSpan={columns.length}>
+                  <EmptyState.Root size="lg">
+                    <EmptyState.Content py={24}>
+                      <EmptyState.Description>
+                        조회된 데이터가 없습니다
+                      </EmptyState.Description>
+                    </EmptyState.Content>
+                  </EmptyState.Root>
+                </Table.Cell>
+              </Table.Row>
+            ) : pagination ? (
+              currentData.map((row, index) => renderRow(row, index))
+            ) : (
+              displayRows.map((row, index) => renderRow(row, index))
+            )}
+          </Table.Body>
+        </Table.Root>
+      </Table.ScrollArea>
       {pagination && hasData && (
         <PaginationRoot
           count={totalItems}
@@ -264,6 +266,6 @@ export const DataTable = <T,>({
           </HStack>
         </PaginationRoot>
       )}
-    </Table.ScrollArea>
+    </>
   );
 };

--- a/src/frontend/src/core/table/data-table.tsx
+++ b/src/frontend/src/core/table/data-table.tsx
@@ -200,7 +200,12 @@ export const DataTable = <T,>({
   return (
     <>
       <Table.ScrollArea maxHeight="4xl" {...rest}>
-        <Table.Root interactive={isInteractive} showColumnBorder stickyHeader>
+        <Table.Root
+          interactive={isInteractive}
+          showColumnBorder
+          stickyHeader
+          width="max-content"
+        >
           <Table.Header>
             <Table.Row>
               {hasData &&


### PR DESCRIPTION
이미지가 포함된 셀 내용 등이 고려되지 않은 테이블 내 너비 설정 때문에 셀 영역을 넘어가는 문제가 있었고, 내용에 맞는 자연스러운 너비로 확장될 수 있도록 수정함.