### PR TITLE
Dialog 컴포넌트 Query, Form 통합을 통해 모달 UX 개선

### DIFF
--- a/src/frontend/src/core/dialog/dialog.tsx
+++ b/src/frontend/src/core/dialog/dialog.tsx
@@ -1,7 +1,12 @@
+import { NoInfer, TypedDocumentNode } from "@apollo/client";
 import { DialogRootProps, Portal } from "@chakra-ui/react";
-import { PropsWithChildren } from "react";
+import { ReactNode, useEffect, useMemo } from "react";
+import { FieldValues, FormProvider } from "react-hook-form";
 
 import { DialogBackdrop, DialogRoot } from "~/core/chakra-components/ui/dialog";
+import { Form, useMutationForm, UseMutationFormOptions } from "~/core/form";
+import { useQuery } from "~/core/graphql";
+import { BlockLoader } from "~/core/loader";
 
 import { DialogBody } from "./dialog-body";
 import { DialogCloseButton } from "./dialog-close-button";
@@ -10,13 +15,174 @@ import { DialogFooter } from "./dialog-footer";
 import { DialogHeader } from "./dialog-header";
 import { DialogTrigger } from "./dialog-trigger";
 
-export type DialogProps = PropsWithChildren & {
+export type DialogProps = {
   onClose: () => void;
   open: boolean;
+};
+
+type DialogComponentPropsWithQuery<
+  TInput extends FieldValues,
+  TMutation,
+  TQuery,
+  TVariables,
+> = DialogProps & {
+  children:
+    | ReactNode
+    | ((
+        props: ReturnType<typeof useMutationForm<TInput, TMutation>> & {
+          queryData: TQuery;
+          refetch: () => void;
+        }
+      ) => ReactNode);
+  defaultValues?: (data: TQuery) => TInput;
+  form?: Pick<
+    UseMutationFormOptions<TInput, TMutation>,
+    "mutation" | "onComplete" | "schema"
+  >;
+  query: TypedDocumentNode<TQuery, TVariables>;
+  queryVariables?: NoInfer<TVariables>;
   size?: DialogRootProps["size"];
 };
 
-const Dialog = ({ children, onClose, open, size = "md" }: DialogProps) => {
+type DialogComponentPropsWithoutQuery<
+  TInput extends FieldValues,
+  TMutation,
+> = DialogProps & {
+  children:
+    | ReactNode
+    | ((
+        props: ReturnType<typeof useMutationForm<TInput, TMutation>> & {
+          queryData: never;
+        }
+      ) => ReactNode);
+  defaultValues?: never;
+  form?: Pick<
+    UseMutationFormOptions<TInput, TMutation>,
+    "mutation" | "onComplete" | "schema"
+  >;
+  query?: never;
+  queryVariables?: never;
+  size?: DialogRootProps["size"];
+};
+
+type DialogComponentPropsQueryOnly<TQuery, TVariables> = DialogProps & {
+  children:
+    | ReactNode
+    | ((props: { queryData: TQuery; refetch: () => void }) => ReactNode);
+  defaultValues?: never;
+  form?: never;
+  query: TypedDocumentNode<TQuery, TVariables>;
+  queryVariables?: NoInfer<TVariables>;
+  size?: DialogRootProps["size"];
+};
+
+type DialogImplementationProps =
+  | DialogComponentPropsQueryOnly<any, any>
+  | DialogComponentPropsWithQuery<FieldValues, any, any, any>
+  | DialogComponentPropsWithoutQuery<FieldValues, any>;
+
+function Dialog<TQuery, TVariables = {}>(
+  props: DialogComponentPropsQueryOnly<TQuery, TVariables>
+): JSX.Element;
+function Dialog<TInput extends FieldValues, TMutation, TQuery, TVariables = {}>(
+  props: DialogComponentPropsWithQuery<TInput, TMutation, TQuery, TVariables>
+): JSX.Element;
+function Dialog<TInput extends FieldValues, TMutation>(
+  props: DialogComponentPropsWithoutQuery<TInput, TMutation>
+): JSX.Element;
+function Dialog(props: DialogImplementationProps): JSX.Element {
+  const {
+    children,
+    defaultValues,
+    form,
+    onClose,
+    open,
+    query,
+    queryVariables,
+    size = "md",
+  } = props;
+  const queryResult = query
+    ? useQuery(query, {
+        skip: !open,
+        variables: queryVariables,
+      })
+    : null;
+
+  const formReturn = form
+    ? useMutationForm({
+        defaultValues: undefined,
+        mutation: form.mutation,
+        onComplete: form.onComplete,
+        schema: form.schema,
+      })
+    : null;
+
+  useEffect(() => {
+    if (
+      formReturn &&
+      defaultValues &&
+      queryResult?.data &&
+      !queryResult.loading
+    ) {
+      formReturn.reset(defaultValues(queryResult.data));
+    }
+  }, [defaultValues, formReturn, queryResult?.data, queryResult?.loading]);
+
+  const isLoading = queryResult?.loading || false;
+  const error = queryResult?.error;
+  const queryData = queryResult?.data;
+
+  const renderedChildren = useMemo(() => {
+    if (isLoading) {
+      return <BlockLoader />;
+    }
+
+    if (error) {
+      return (
+        <>
+          <DialogHeader>에러</DialogHeader>
+          <DialogBody>에러가 발생했습니다: {error.message}</DialogBody>
+        </>
+      );
+    }
+
+    if (query && !queryData) {
+      return (
+        <>
+          <DialogHeader>에러</DialogHeader>
+          <DialogBody>불러온 데이터가 없습니다.</DialogBody>
+        </>
+      );
+    }
+
+    if (typeof children === "function") {
+      return children({
+        ...(formReturn ?? {}),
+        queryData: queryData ?? {},
+        refetch: queryResult?.refetch ?? (() => {}),
+      } as any);
+    }
+    return children;
+  }, [isLoading, error, query, queryData, children, formReturn, queryResult]);
+
+  const content = useMemo(() => {
+    if (formReturn) {
+      const { onSubmit } = formReturn;
+      return (
+        <Form
+          onSubmit={(e) => {
+            if (e) e.stopPropagation();
+            return onSubmit(e);
+          }}
+        >
+          <DialogContent>{renderedChildren}</DialogContent>
+        </Form>
+      );
+    }
+
+    return <DialogContent>{renderedChildren}</DialogContent>;
+  }, [formReturn, renderedChildren]);
+
   return (
     <DialogRoot
       lazyMount
@@ -28,11 +194,15 @@ const Dialog = ({ children, onClose, open, size = "md" }: DialogProps) => {
     >
       <Portal>
         <DialogBackdrop />
-        {children}
+        {formReturn ? (
+          <FormProvider {...formReturn}>{content}</FormProvider>
+        ) : (
+          content
+        )}
       </Portal>
     </DialogRoot>
   );
-};
+}
 
 Dialog.Body = DialogBody;
 Dialog.CloseButton = DialogCloseButton;

--- a/src/frontend/src/core/dialog/use-dialog.tsx
+++ b/src/frontend/src/core/dialog/use-dialog.tsx
@@ -1,13 +1,10 @@
-import { Center, useDisclosure } from "@chakra-ui/react";
+import { useDisclosure } from "@chakra-ui/react";
 import {
   ComponentPropsWithoutRef,
   createElement,
   ElementType,
-  Suspense,
   useState,
 } from "react";
-
-import { BlockLoader } from "../loader";
 
 export type UseDialogProps<T extends ElementType> = {
   dialog: T;
@@ -40,15 +37,11 @@ export const useDialog = <T extends ElementType>({
   const renderModal = () => {
     if (!open || disabled) return null;
 
-    return (
-      <Suspense fallback={<BackdropLoader />}>
-        {createElement(dialog, {
-          ...currentDialogProps,
-          onClose,
-          open,
-        })}
-      </Suspense>
-    );
+    return createElement(dialog, {
+      ...currentDialogProps,
+      onClose,
+      open,
+    });
   };
 
   return {
@@ -58,20 +51,4 @@ export const useDialog = <T extends ElementType>({
     open,
     renderModal,
   };
-};
-
-const BackdropLoader = () => {
-  return (
-    <Center
-      bg="blackAlpha.600"
-      bottom={0}
-      left={0}
-      position="fixed"
-      right={0}
-      top={0}
-      zIndex="modal"
-    >
-      <BlockLoader />
-    </Center>
-  );
 };

--- a/src/frontend/src/core/form/form.tsx
+++ b/src/frontend/src/core/form/form.tsx
@@ -1,4 +1,3 @@
-import { Flex, FlexProps } from "@chakra-ui/react";
 import * as RHF from "react-hook-form";
 
 import { Checkbox } from "./checkbox";
@@ -13,16 +12,17 @@ import { Select } from "./select";
 import { SubmitButton } from "./submit-button";
 
 export type FormProps<FormValues extends RHF.FieldValues = RHF.FieldValues> =
-  FlexProps & {
+  React.DetailedHTMLProps<
+    React.FormHTMLAttributes<HTMLFormElement>,
+    HTMLFormElement
+  > & {
     onSubmit: ReturnType<RHF.UseFormReturn<FormValues>["handleSubmit"]>;
   };
 
 const Form = <FormValues extends RHF.FieldValues>({
   onSubmit,
   ...otherProps
-}: FormProps<FormValues>) => (
-  <Flex as="form" direction="column" onSubmit={onSubmit} {...otherProps} />
-);
+}: FormProps<FormValues>) => <form onSubmit={onSubmit} {...otherProps} />;
 
 Form.Checkbox = Checkbox;
 Form.Field = Field;

--- a/src/frontend/src/core/form/mutation-form.tsx
+++ b/src/frontend/src/core/form/mutation-form.tsx
@@ -9,29 +9,28 @@ import {
   UseFormWatch,
 } from "react-hook-form";
 
-import { Form, FormProps } from "./form";
+import { Form } from "./form";
 import { UseMutationFormOptions, useMutationForm } from "./use-mutation-form";
 
 export type MutationFormProps<
   FormValues extends FieldValues = FieldValues,
   MutationResult = any,
-> = Omit<FormProps, "children" | "onSubmit"> &
-  Pick<
-    UseMutationFormOptions<FormValues, MutationResult>,
-    "defaultValues" | "mutation" | "onComplete" | "schema"
-  > & {
-    children:
-      | ReactNode
-      | ((form: {
-          control: Control<FormValues>;
-          formState: FormState<FormValues>;
-          register: UseFormRegister<FormValues>;
-          setValue: UseFormSetValue<FormValues>;
-          submit: (e?: React.BaseSyntheticEvent) => Promise<void>;
-          watch: UseFormWatch<FormValues>;
-        }) => JSX.Element);
-    preventEnterSubmit?: boolean;
-  };
+> = Pick<
+  UseMutationFormOptions<FormValues, MutationResult>,
+  "defaultValues" | "mutation" | "onComplete" | "schema"
+> & {
+  children:
+    | ReactNode
+    | ((form: {
+        control: Control<FormValues>;
+        formState: FormState<FormValues>;
+        register: UseFormRegister<FormValues>;
+        setValue: UseFormSetValue<FormValues>;
+        submit: (e?: React.BaseSyntheticEvent) => Promise<void>;
+        watch: UseFormWatch<FormValues>;
+      }) => JSX.Element);
+  preventEnterSubmit?: boolean;
+};
 
 export const MutationForm = <
   FormValues extends FieldValues = FieldValues,
@@ -43,7 +42,6 @@ export const MutationForm = <
   onComplete,
   preventEnterSubmit,
   schema,
-  ...otherProps
 }: MutationFormProps<FormValues, MutationResult>) => {
   const { onSubmit, ...useFormReturn } = useMutationForm<
     FormValues,
@@ -70,7 +68,6 @@ export const MutationForm = <
 
           return onSubmit(e);
         }}
-        {...otherProps}
       >
         {typeof children === "function"
           ? children({ ...useFormReturn, submit: onSubmit })

--- a/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/gold-exchange-rate-setting-dialog.tsx
+++ b/src/frontend/src/pages/content-wage-list/tabs/content-wage-table-tab/components/gold-exchange-rate-setting-dialog.tsx
@@ -1,12 +1,12 @@
 import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
-import { useSafeQuery } from "~/core/graphql";
 import {
   GoldExchangeRateEditDocument,
   GoldExchangeRateEditInput,
   GoldExchangeRateEditMutation,
   GoldExchangeRateSettingDialogDocument,
+  GoldExchangeRateSettingDialogQuery,
 } from "~/core/graphql/generated";
 
 const schema = z.object({
@@ -19,33 +19,37 @@ export const GoldExchangeRateSettingDialog = ({
 }: {
   onComplete: () => void;
 } & DialogProps) => {
-  const { data } = useSafeQuery(GoldExchangeRateSettingDialogDocument);
-
-  const { goldExchangeRate } = data;
-
   return (
-    <Dialog {...dialogProps}>
-      <Form.Mutation<GoldExchangeRateEditInput, GoldExchangeRateEditMutation>
-        defaultValues={{
-          krwAmount: goldExchangeRate.krwAmount,
-        }}
-        mutation={GoldExchangeRateEditDocument}
-        onComplete={() => {
+    <Dialog<
+      GoldExchangeRateEditInput,
+      GoldExchangeRateEditMutation,
+      GoldExchangeRateSettingDialogQuery
+    >
+      defaultValues={(data) => ({
+        krwAmount: data.goldExchangeRate.krwAmount,
+      })}
+      form={{
+        mutation: GoldExchangeRateEditDocument,
+        onComplete: () => {
           dialogProps.onClose();
           onComplete();
           toaster.create({
             title: "골드 환율이 수정되었습니다.",
             type: "success",
           });
-        }}
-        schema={schema}
-      >
-        <Dialog.Content>
+        },
+        schema,
+      }}
+      query={GoldExchangeRateSettingDialogDocument}
+      {...dialogProps}
+    >
+      {({ queryData }) => (
+        <>
           <Dialog.Header>골드 환율 설정</Dialog.Header>
           <Dialog.Body>
             <Form.Body>
               <Form.Field
-                label={`${goldExchangeRate.goldAmount}골드 당 원(KRW)`}
+                label={`${queryData.goldExchangeRate.goldAmount}골드 당 원(KRW)`}
                 name="krwAmount"
               >
                 <Form.NumberInput min={0} />
@@ -58,8 +62,8 @@ export const GoldExchangeRateSettingDialog = ({
               <Form.SubmitButton />
             </Form.Footer>
           </Dialog.Footer>
-        </Dialog.Content>
-      </Form.Mutation>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.tsx
+++ b/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.tsx
@@ -1,12 +1,13 @@
 import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
-import { useSafeQuery } from "~/core/graphql";
 import {
+  UserExtraItemPriceEditDialogDocument,
   UserItemPriceEditDocument,
   UserItemPriceEditInput,
   UserItemPriceEditMutation,
-  UserExtraItemPriceEditDialogDocument,
+  UserExtraItemPriceEditDialogQuery,
+  UserExtraItemPriceEditDialogQueryVariables,
 } from "~/core/graphql/generated";
 
 const schema = z.object({
@@ -24,36 +25,36 @@ export const UserExtraItemPriceEditDialog = ({
   onComplete,
   ...dialogProps
 }: UserExtraItemPriceEditDialogProps & DialogProps) => {
-  const { data } = useSafeQuery(UserExtraItemPriceEditDialogDocument, {
-    variables: {
-      id: itemId,
-    },
-  });
-
-  const {
-    item: { userItem },
-  } = data;
-
   return (
-    <Dialog {...dialogProps}>
-      <Form.Mutation<UserItemPriceEditInput, UserItemPriceEditMutation>
-        defaultValues={{
-          id: userItem.id,
-          price: userItem.price,
-        }}
-        mutation={UserItemPriceEditDocument}
-        onComplete={() => {
+    <Dialog<
+      UserItemPriceEditInput,
+      UserItemPriceEditMutation,
+      UserExtraItemPriceEditDialogQuery,
+      UserExtraItemPriceEditDialogQueryVariables
+    >
+      defaultValues={(data) => ({
+        id: data.item.userItem.id,
+        price: data.item.userItem.price,
+      })}
+      form={{
+        mutation: UserItemPriceEditDocument,
+        onComplete: () => {
           dialogProps.onClose();
           onComplete();
           toaster.create({
             title: "기타 아이템의 개당 골드 가치가 수정되었습니다.",
             type: "success",
           });
-        }}
-        schema={schema}
-      >
-        <Dialog.Content>
-          <Dialog.Header>{data.item.name} - 골드 가치 수정</Dialog.Header>
+        },
+        schema,
+      }}
+      query={UserExtraItemPriceEditDialogDocument}
+      queryVariables={{ id: itemId }}
+      {...dialogProps}
+    >
+      {({ queryData }) => (
+        <>
+          <Dialog.Header>{queryData.item.name} - 골드 가치 수정</Dialog.Header>
           <Dialog.Body>
             <Form.Body>
               <Form.Field label="개당 골드" name="price">
@@ -67,8 +68,8 @@ export const UserExtraItemPriceEditDialog = ({
               <Form.SubmitButton />
             </Form.Footer>
           </Dialog.Footer>
-        </Dialog.Content>
-      </Form.Mutation>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/src/frontend/src/shared/content/content-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-details-dialog.tsx
@@ -21,6 +21,8 @@ import { DialogCloseButton } from "~/core/dialog/dialog-close-button";
 import { useSafeQuery } from "~/core/graphql";
 import {
   ContentDetailsDialogDocument,
+  ContentDetailsDialogQuery,
+  ContentDetailsDialogQueryVariables,
   ContentDetailsDialogWageSectionDocument,
 } from "~/core/graphql/generated";
 import { TableSkeleton } from "~/core/loader";
@@ -44,132 +46,132 @@ export const ContentDetailsDialog = ({
   onComplete,
   open,
 }: ContentDetailsDialogProps) => {
-  const { data, refetch } = useSafeQuery(ContentDetailsDialogDocument, {
-    variables: {
-      contentId,
-    },
-  });
   const { isAuthenticated } = useAuth();
 
-  const basicInfoItems = [
-    {
-      label: "종류",
-      value: (
-        <ItemNameWithImage
-          name={data.content.contentCategory.name}
-          src={data.content.contentCategory.imageUrl}
-        />
-      ),
-    },
-    { label: "레벨", value: data.content.level },
-    { label: "이름", value: data.content.displayName },
-  ];
-
-  const contentRewardsItems = data.content.contentRewards.map(
-    (contentReward) => ({
-      label: (
-        <ItemNameWithImage
-          name={contentReward.item.name}
-          reverse
-          src={contentReward.item.imageUrl}
-        />
-      ),
-      value: contentReward.averageQuantity || "-",
-    })
-  );
-
-  const contentSeeMoreRewardsItems = data.content.contentSeeMoreRewards.map(
-    (contentSeeMoreReward) => ({
-      label: (
-        <ItemNameWithImage
-          name={contentSeeMoreReward.item.name}
-          reverse
-          src={contentSeeMoreReward.item.imageUrl}
-        />
-      ),
-      value: contentSeeMoreReward.quantity,
-    })
-  );
-
   return (
-    <Dialog
+    <Dialog<ContentDetailsDialogQuery, ContentDetailsDialogQueryVariables>
       onClose={() => {
         onClose();
         onComplete();
       }}
       open={open}
+      query={ContentDetailsDialogDocument}
+      queryVariables={{ contentId }}
       size="xl"
     >
-      <Dialog.Content>
-        <Dialog.Header>컨텐츠 상세 정보</Dialog.Header>
-        <Dialog.Body>
-          <Flex direction="column" gap={4}>
-            <Section title="기본 정보">
-              <DataGrid items={basicInfoItems} />
-            </Section>
-            <ContentWageSection contentId={contentId} items={data.items} />
-            <Section
-              title={
-                <Flex alignItems="center" gap={2}>
-                  <Text>보상 정보</Text>
-                  <Dialog.Trigger
-                    dialog={ContentRewardEditDialog}
-                    dialogProps={{
-                      contentId,
-                      onComplete: refetch,
-                    }}
-                    disabled={!isAuthenticated}
-                  >
-                    <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
-                      <IconButton
+      {({ queryData: data, refetch }) => {
+        const basicInfoItems = [
+          {
+            label: "종류",
+            value: (
+              <ItemNameWithImage
+                name={data.content.contentCategory.name}
+                src={data.content.contentCategory.imageUrl}
+              />
+            ),
+          },
+          { label: "레벨", value: data.content.level },
+          { label: "이름", value: data.content.displayName },
+        ];
+
+        const contentRewardsItems = data.content.contentRewards.map(
+          (contentReward) => ({
+            label: (
+              <ItemNameWithImage
+                name={contentReward.item.name}
+                reverse
+                src={contentReward.item.imageUrl}
+              />
+            ),
+            value: contentReward.averageQuantity || "-",
+          })
+        );
+
+        const contentSeeMoreRewardsItems =
+          data.content.contentSeeMoreRewards.map((contentSeeMoreReward) => ({
+            label: (
+              <ItemNameWithImage
+                name={contentSeeMoreReward.item.name}
+                reverse
+                src={contentSeeMoreReward.item.imageUrl}
+              />
+            ),
+            value: contentSeeMoreReward.quantity,
+          }));
+
+        return (
+          <>
+            <Dialog.Header>컨텐츠 상세 정보</Dialog.Header>
+            <Dialog.Body>
+              <Flex direction="column" gap={4}>
+                <Section title="기본 정보">
+                  <DataGrid items={basicInfoItems} />
+                </Section>
+                <ContentWageSection contentId={contentId} items={data.items} />
+                <Section
+                  title={
+                    <Flex alignItems="center" gap={2}>
+                      <Text>보상 정보</Text>
+                      <Dialog.Trigger
+                        dialog={ContentRewardEditDialog}
+                        dialogProps={{
+                          contentId,
+                          onComplete: refetch,
+                        }}
                         disabled={!isAuthenticated}
-                        size="2xs"
-                        variant="surface"
                       >
-                        <IoIosSettings />
-                      </IconButton>
-                    </LoginTooltip>
-                  </Dialog.Trigger>
-                </Flex>
-              }
-            >
-              <DataGrid items={contentRewardsItems} />
-            </Section>
-            {contentSeeMoreRewardsItems.length > 0 && (
-              <Section
-                title={
-                  <Flex alignItems="center" gap={2}>
-                    <Text>더보기 보상 정보</Text>
-                    <Dialog.Trigger
-                      dialog={ContentSeeMoreRewardEditDialog}
-                      dialogProps={{
-                        contentId,
-                        onComplete: refetch,
-                      }}
-                      disabled={!isAuthenticated}
-                    >
-                      <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
-                        <IconButton
+                        <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
+                          <IconButton
+                            disabled={!isAuthenticated}
+                            size="2xs"
+                            variant="surface"
+                          >
+                            <IoIosSettings />
+                          </IconButton>
+                        </LoginTooltip>
+                      </Dialog.Trigger>
+                    </Flex>
+                  }
+                >
+                  <DataGrid items={contentRewardsItems} />
+                </Section>
+                {contentSeeMoreRewardsItems.length > 0 && (
+                  <Section
+                    title={
+                      <Flex alignItems="center" gap={2}>
+                        <Text>더보기 보상 정보</Text>
+                        <Dialog.Trigger
+                          dialog={ContentSeeMoreRewardEditDialog}
+                          dialogProps={{
+                            contentId,
+                            onComplete: refetch,
+                          }}
                           disabled={!isAuthenticated}
-                          size="2xs"
-                          variant="surface"
                         >
-                          <IoIosSettings />
-                        </IconButton>
-                      </LoginTooltip>
-                    </Dialog.Trigger>
-                  </Flex>
-                }
-              >
-                <DataGrid items={contentSeeMoreRewardsItems} />
-              </Section>
-            )}
-          </Flex>
-        </Dialog.Body>
-        <Dialog.Footer>
-          <DialogCloseButton />
-        </Dialog.Footer>
-      </Dialog.Content>
+                          <LoginTooltip content="로그인 후 보상을 수정할 수 있습니다">
+                            <IconButton
+                              disabled={!isAuthenticated}
+                              size="2xs"
+                              variant="surface"
+                            >
+                              <IoIosSettings />
+                            </IconButton>
+                          </LoginTooltip>
+                        </Dialog.Trigger>
+                      </Flex>
+                    }
+                  >
+                    <DataGrid items={contentSeeMoreRewardsItems} />
+                  </Section>
+                )}
+              </Flex>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <DialogCloseButton />
+            </Dialog.Footer>
+          </>
+        );
+      }}
     </Dialog>
   );
 };

--- a/src/frontend/src/shared/content/content-group-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-group-details-dialog.tsx
@@ -23,6 +23,8 @@ import {
   ContentDetailsDialogDocument,
   ContentDetailsDialogWageSectionDocument,
   ContentGroupDetailsDialogDocument,
+  ContentGroupDetailsDialogQuery,
+  ContentGroupDetailsDialogQueryVariables,
 } from "~/core/graphql/generated";
 import { TableSkeleton } from "~/core/loader";
 import { Section } from "~/core/section";
@@ -34,10 +36,10 @@ import { ContentDurationEditDialog } from "./content-duration-edit-dialog";
 import { ContentRewardEditDialog } from "./content-reward-edit-dialog";
 import { ContentSeeMoreRewardEditDialog } from "./content-see-more-reward-edit-dialog";
 
-type ContentGroupDetailsDialogProps = DialogProps & {
+type ContentGroupDetailsDialogProps = {
   contentIds: number[];
   onComplete: () => void;
-};
+} & DialogProps;
 
 export const ContentGroupDetailsDialog = ({
   contentIds,
@@ -45,42 +47,53 @@ export const ContentGroupDetailsDialog = ({
   onComplete,
   open,
 }: ContentGroupDetailsDialogProps) => {
-  const { data } = useSafeQuery(ContentGroupDetailsDialogDocument, {
-    variables: {
-      contentIds,
-    },
-  });
-
   return (
-    <Dialog
+    <Dialog<
+      ContentGroupDetailsDialogQuery,
+      ContentGroupDetailsDialogQueryVariables
+    >
       onClose={() => {
         onClose();
         onComplete();
       }}
       open={open}
+      query={ContentGroupDetailsDialogDocument}
+      queryVariables={{ contentIds }}
       size="xl"
     >
-      <Dialog.Content>
-        <Dialog.Header>컨텐츠 상세 정보</Dialog.Header>
-        <Dialog.Body>
-          <Flex direction="column" gap={4}>
-            {data.contentGroup.contents.length > 1 ? (
-              data.contentGroup.contents.map((content) => (
-                <Section key={content.id} title={`${content.gate}관문`}>
-                  <ContentGroupSection contentId={content.id} />
-                </Section>
-              ))
-            ) : (
-              <ContentGroupSection
-                contentId={data.contentGroup.contents[0].id}
-              />
-            )}
-          </Flex>
-        </Dialog.Body>
-        <Dialog.Footer>
-          <DialogCloseButton />
-        </Dialog.Footer>
-      </Dialog.Content>
+      {({ queryData: data }) => (
+        <>
+          <Dialog.Header>컨텐츠 상세 정보</Dialog.Header>
+          <Dialog.Body>
+            <Flex direction="column" gap={4}>
+              <Suspense
+                fallback={
+                  <Flex direction="column" gap={4}>
+                    <TableSkeleton line={3} />
+                    <TableSkeleton line={3} />
+                    <TableSkeleton line={3} />
+                  </Flex>
+                }
+              >
+                {data.contentGroup.contents.length > 1 ? (
+                  data.contentGroup.contents.map((content) => (
+                    <Section key={content.id} title={`${content.gate}관문`}>
+                      <ContentGroupSection contentId={content.id} />
+                    </Section>
+                  ))
+                ) : (
+                  <ContentGroupSection
+                    contentId={data.contentGroup.contents[0].id}
+                  />
+                )}
+              </Suspense>
+            </Flex>
+          </Dialog.Body>
+          <Dialog.Footer>
+            <DialogCloseButton />
+          </Dialog.Footer>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/src/frontend/src/shared/content/content-reward-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-reward-edit-dialog.tsx
@@ -4,9 +4,10 @@ import { InputGroup } from "~/core/chakra-components/ui/input-group";
 import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
-import { useSafeQuery } from "~/core/graphql";
 import {
   ContentRewardEditDialogDocument,
+  ContentRewardEditDialogQuery,
+  ContentRewardEditDialogQueryVariables,
   ContentRewardsEditDocument,
   ContentRewardsEditInput,
   ContentRewardsEditMutation,
@@ -36,120 +37,122 @@ export const ContentRewardEditDialog = ({
   onComplete,
   ...dialogProps
 }: ContentRewardEditDialogProps & DialogProps) => {
-  const { data } = useSafeQuery(ContentRewardEditDialogDocument, {
-    variables: {
-      id: contentId,
-    },
-  });
-
   return (
-    <Dialog {...dialogProps}>
-      <Form.Mutation<ContentRewardsEditInput, ContentRewardsEditMutation>
-        defaultValues={{
-          contentRewards: data.content.contentRewards.map((reward) => ({
-            contentId,
-            itemId: reward.item.id,
-            averageQuantity: reward.averageQuantity,
-            isSellable: reward.isSellable,
-          })),
-          isReportable: true,
-        }}
-        mutation={ContentRewardsEditDocument}
-        onComplete={() => {
+    <Dialog<
+      ContentRewardsEditInput,
+      ContentRewardsEditMutation,
+      ContentRewardEditDialogQuery,
+      ContentRewardEditDialogQueryVariables
+    >
+      defaultValues={(data) => ({
+        contentRewards: data.content.contentRewards.map((reward) => ({
+          averageQuantity: reward.averageQuantity,
+          contentId,
+          isSellable: reward.isSellable,
+          itemId: reward.item.id,
+        })),
+        isReportable: true,
+      })}
+      form={{
+        mutation: ContentRewardsEditDocument,
+        onComplete: () => {
           dialogProps.onClose();
           onComplete();
           toaster.create({
             title: "컨텐츠 보상이 수정되었습니다.",
             type: "success",
           });
-        }}
-        schema={schema}
-      >
-        {({ setValue, watch }) => (
-          <Dialog.Content>
-            <Dialog.Header>
-              {data.content.displayName} - 보상 수정
-            </Dialog.Header>
-            <Dialog.Body>
-              <Form.Body>
-                {data.content.contentRewards.map((reward, index) => (
-                  <Form.Field
-                    key={reward.id}
-                    label={reward.item.name}
-                    name={`contentRewards.${index}.averageQuantity`}
-                  >
-                    <InputGroup
-                      endElement={
-                        <NativeSelect.Root
-                          me="-1"
-                          size="xs"
-                          variant="plain"
-                          width="auto"
-                        >
-                          <NativeSelect.Field
-                            fontSize="sm"
-                            onChange={(e) => {
-                              setValue(
-                                `contentRewards.${index}.isSellable`,
-                                e.target.value === "true"
-                              );
-                            }}
-                            value={
-                              watch(`contentRewards.${index}.isSellable`)
-                                ? "true"
-                                : "false"
-                            }
-                          >
-                            <option style={{ color: "black" }} value="true">
-                              거래 가능
-                            </option>
-                            <option style={{ color: "black" }} value="false">
-                              귀속
-                            </option>
-                          </NativeSelect.Field>
-                          <NativeSelect.Indicator />
-                        </NativeSelect.Root>
-                      }
-                      w="full"
-                    >
-                      <Form.Input
-                        css={{
-                          "&::-webkit-outer-spin-button, &::-webkit-inner-spin-button":
-                            {
-                              "-webkit-appearance": "none",
-                              margin: 0,
-                            },
-                          "&[type=number]": {
-                            "-moz-appearance": "textfield",
-                          },
-                        }}
-                        type="number"
-                      />
-                    </InputGroup>
-                  </Form.Field>
-                ))}
-                <Form.Field name="isReportable" optional>
-                  <Form.Checkbox>저장 후 데이터 제보</Form.Checkbox>
-                </Form.Field>
-                <Dialog.Trigger
-                  dialog={ContentRewardReportDialog}
-                  dialogProps={{
-                    contentId,
-                  }}
+        },
+        schema,
+      }}
+      query={ContentRewardEditDialogDocument}
+      queryVariables={{ id: contentId }}
+      {...dialogProps}
+    >
+      {({ queryData, setValue, watch }) => (
+        <>
+          <Dialog.Header>
+            {queryData.content.displayName} - 보상 수정
+          </Dialog.Header>
+          <Dialog.Body>
+            <Form.Body>
+              {queryData.content.contentRewards.map((reward, index) => (
+                <Form.Field
+                  key={reward.id}
+                  label={reward.item.name}
+                  name={`contentRewards.${index}.averageQuantity`}
                 >
-                  <Link variant="underline">저장없이 제보만하기</Link>
-                </Dialog.Trigger>
-              </Form.Body>
-            </Dialog.Body>
-            <Dialog.Footer>
-              <Form.Footer>
-                <Dialog.CloseButton />
-                <Form.SubmitButton />
-              </Form.Footer>
-            </Dialog.Footer>
-          </Dialog.Content>
-        )}
-      </Form.Mutation>
+                  <InputGroup
+                    endElement={
+                      <NativeSelect.Root
+                        me="-1"
+                        size="xs"
+                        variant="plain"
+                        width="auto"
+                      >
+                        <NativeSelect.Field
+                          fontSize="sm"
+                          onChange={(e) => {
+                            setValue(
+                              `contentRewards.${index}.isSellable`,
+                              e.target.value === "true"
+                            );
+                          }}
+                          value={
+                            watch(`contentRewards.${index}.isSellable`)
+                              ? "true"
+                              : "false"
+                          }
+                        >
+                          <option style={{ color: "black" }} value="true">
+                            거래 가능
+                          </option>
+                          <option style={{ color: "black" }} value="false">
+                            귀속
+                          </option>
+                        </NativeSelect.Field>
+                        <NativeSelect.Indicator />
+                      </NativeSelect.Root>
+                    }
+                    w="full"
+                  >
+                    <Form.Input
+                      css={{
+                        "&::-webkit-outer-spin-button, &::-webkit-inner-spin-button":
+                          {
+                            "-webkit-appearance": "none",
+                            margin: 0,
+                          },
+                        "&[type=number]": {
+                          "-moz-appearance": "textfield",
+                        },
+                      }}
+                      type="number"
+                    />
+                  </InputGroup>
+                </Form.Field>
+              ))}
+              <Form.Field name="isReportable" optional>
+                <Form.Checkbox>저장 후 데이터 제보</Form.Checkbox>
+              </Form.Field>
+              <Dialog.Trigger
+                dialog={ContentRewardReportDialog}
+                dialogProps={{
+                  contentId,
+                }}
+              >
+                <Link variant="underline">저장없이 제보만하기</Link>
+              </Dialog.Trigger>
+            </Form.Body>
+          </Dialog.Body>
+          <Dialog.Footer>
+            <Form.Footer>
+              <Dialog.CloseButton />
+              <Form.SubmitButton />
+            </Form.Footer>
+          </Dialog.Footer>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.tsx
@@ -1,12 +1,13 @@
 import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
-import { useSafeQuery } from "~/core/graphql";
 import {
   ContentSeeMoreRewardEditDialogDocument,
   ContentSeeMoreRewardsEditDocument,
   ContentSeeMoreRewardsEditInput,
   ContentSeeMoreRewardsEditMutation,
+  ContentSeeMoreRewardEditDialogQuery,
+  ContentSeeMoreRewardEditDialogQueryVariables,
 } from "~/core/graphql/generated";
 
 const schema = z.object({
@@ -29,45 +30,46 @@ export const ContentSeeMoreRewardEditDialog = ({
   onComplete,
   ...dialogProps
 }: ContentSeeMoreRewardEditDialogProps & DialogProps) => {
-  const { data } = useSafeQuery(ContentSeeMoreRewardEditDialogDocument, {
-    variables: {
-      id: contentId,
-    },
-  });
-
   return (
-    <Dialog {...dialogProps}>
-      <Form.Mutation<
-        ContentSeeMoreRewardsEditInput,
-        ContentSeeMoreRewardsEditMutation
-      >
-        defaultValues={{
-          contentSeeMoreRewards: data.content.contentSeeMoreRewards.map(
-            (reward) => ({
-              contentId,
-              itemId: reward.item.id,
-              quantity: reward.quantity,
-            })
-          ),
-        }}
-        mutation={ContentSeeMoreRewardsEditDocument}
-        onComplete={() => {
+    <Dialog<
+      ContentSeeMoreRewardsEditInput,
+      ContentSeeMoreRewardsEditMutation,
+      ContentSeeMoreRewardEditDialogQuery,
+      ContentSeeMoreRewardEditDialogQueryVariables
+    >
+      defaultValues={(data) => ({
+        contentSeeMoreRewards: data.content.contentSeeMoreRewards.map(
+          (reward) => ({
+            contentId,
+            itemId: reward.item.id,
+            quantity: reward.quantity,
+          })
+        ),
+      })}
+      form={{
+        mutation: ContentSeeMoreRewardsEditDocument,
+        onComplete: () => {
           dialogProps.onClose();
           onComplete();
           toaster.create({
             title: "더보기 보상이 수정되었습니다.",
             type: "success",
           });
-        }}
-        schema={schema}
-      >
-        <Dialog.Content>
+        },
+        schema,
+      }}
+      query={ContentSeeMoreRewardEditDialogDocument}
+      queryVariables={{ id: contentId }}
+      {...dialogProps}
+    >
+      {({ queryData }) => (
+        <>
           <Dialog.Header>
-            {data.content.displayName} - 더보기 보상 수정
+            {queryData.content.displayName} - 더보기 보상 수정
           </Dialog.Header>
           <Dialog.Body>
             <Form.Body>
-              {data.content.contentSeeMoreRewards.map((reward, index) => (
+              {queryData.content.contentSeeMoreRewards.map((reward, index) => (
                 <Form.Field
                   key={reward.id}
                   label={reward.item.name}
@@ -84,8 +86,8 @@ export const ContentSeeMoreRewardEditDialog = ({
               <Form.SubmitButton />
             </Form.Footer>
           </Dialog.Footer>
-        </Dialog.Content>
-      </Form.Mutation>
+        </>
+      )}
     </Dialog>
   );
 };


### PR DESCRIPTION
주요 문제:
  - 모달 외부에서 useSafeQuery로 로딩 처리 후 열리는 구조로 UX가 부자연스러움

해결 방향:
  - Dialog 내부에서 query 및 mutation form을 중앙 관리하여 모달을 먼저 열고 내부에서 로딩 및 에러 표시

Chakra UI 제약사항으로 인한 Form 통합 필요성:
  - DialogContent는 직계 자식으로 Header/Body/Footer만 허용
  - 중간에 Form 같은 non-UI 요소조차 끼게되면 UI 레이아웃 깨짐
  - query를 Dialog에서 중앙 관리하면 DialogContent도 중앙에서 렌더링 필요 (로딩/에러 상태를 DialogContent 내부에서 분기 처리해야 자연스러운 UX)
  - DialogContent가 중앙에 있으면 Form은 그보다 상위에 위치해야 함
  - 결과적으로 Form도 사용처가 아닌 Dialog 내부에서 중앙 관리 필수

구현:
  - Dialog 컴포넌트에서 query/mutation-form 통합 관리
  - 구조: Dialog > (FormProvider) > Form > DialogContent > 시맨틱 요소들
  - 함수 오버로드로 사용 패턴별 타입 최적화
    - Query only: 2개 제네릭 (TQuery, TVariables?)
    - Form + Query: 4개 제네릭 (TInput, TMutation, TQuery, TVariables?)
    - Form only: 2개 제네릭 (TInput, TMutation)
  - TVariables 기본값으로 variables 없는 경우 생략 가능
  - refetch 함수 children에 전달하여 nested Dialog에서 부모 갱신 가능

close https://github.com/KubrickCode/loa-work/issues/96