### PR TITLE
feat(backend): 전역 에러 처리 인프라 구축

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,51 @@ The backend uses NestJS with a modular structure:
 Key modules:
 
 - `auth/` - OAuth authentication with multiple providers
+- `common/` - Shared utilities, exception handling, filters
 - `content/` - Game content data and calculations
 - `item/` - Item pricing (auction/market items)
 - `exchange-rate/` - Gold-to-KRW conversion rates
 - `user/` - User management and customization
 - `monitoring/` - Prometheus metrics endpoint
+
+### Exception Handling (Backend)
+
+Custom GraphQL exceptions in `common/exception/`:
+
+```typescript
+// Usage: throw from any resolver
+throw new NotFoundException("Content", id);
+throw new ForbiddenException("권한이 없습니다.");
+throw new UnauthorizedException();
+throw new ValidationException("잘못된 입력", "fieldName");
+```
+
+Available exception types:
+
+| Exception               | Code               | Usage              |
+| ----------------------- | ------------------ | ------------------ |
+| `NotFoundException`     | `NOT_FOUND`        | Resource not found |
+| `ForbiddenException`    | `FORBIDDEN`        | Access denied      |
+| `UnauthorizedException` | `UNAUTHORIZED`     | Auth required      |
+| `ValidationException`   | `VALIDATION_ERROR` | Input validation   |
+
+Creating custom exceptions:
+
+```typescript
+import { BaseGraphQLException, ERROR_CODES } from "./base.exception";
+
+export class CustomException extends BaseGraphQLException {
+  constructor(message: string) {
+    super(message, ERROR_CODES.BAD_REQUEST);
+  }
+}
+```
+
+Architecture:
+
+- GraphQL: `formatGraphQLError` handles all GraphQL errors with correlationId
+- HTTP: `AllExceptionsFilter` handles REST endpoints (auto-skips GraphQL context)
+- All responses include `correlationId` for request tracing via `nestjs-cls`
 
 ### Frontend Architecture
 

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -40,6 +40,7 @@
     "express-session": "1.18.1",
     "graphql": "16.9.0",
     "lodash": "4.17.21",
+    "nestjs-cls": "6.1.0",
     "passport": "0.7.0",
     "passport-discord": "0.1.4",
     "passport-google-oauth20": "2.0.0",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
+      nestjs-cls:
+        specifier: 6.1.0
+        version: 6.1.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       passport:
         specifier: 0.7.0
         version: 0.7.0
@@ -4861,6 +4864,18 @@ packages:
       {
         integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
       }
+
+  nestjs-cls@6.1.0:
+    resolution:
+      {
+        integrity: sha512-n4T2aXy5cQxrB8VIGzUF3JBK8lXbRDaWdDS0g7uDKshvYn8NGWMe46PX1p+sb2SxiC0Gjrsff44hkk0kvpS+Ug==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      "@nestjs/common": ">= 10 < 12"
+      "@nestjs/core": ">= 10 < 12"
+      reflect-metadata: "*"
+      rxjs: ">= 7"
 
   nestjs-console@9.0.0:
     resolution:
@@ -9785,6 +9800,13 @@ snapshots:
   negotiator@0.6.4: {}
 
   neo-async@2.6.2: {}
+
+  nestjs-cls@6.1.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1):
+    dependencies:
+      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      reflect-metadata: 0.2.0
+      rxjs: 7.8.1
 
   nestjs-console@9.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0):
     dependencies:

--- a/src/backend/src/common/constants/env.constants.ts
+++ b/src/backend/src/common/constants/env.constants.ts
@@ -1,0 +1,3 @@
+export const NODE_ENV = {
+  PRODUCTION: "production",
+} as const;

--- a/src/backend/src/common/exception/base.exception.ts
+++ b/src/backend/src/common/exception/base.exception.ts
@@ -1,0 +1,34 @@
+import { GraphQLError, GraphQLErrorOptions } from "graphql";
+
+export const ERROR_CODES = {
+  BAD_REQUEST: "BAD_REQUEST",
+  FORBIDDEN: "FORBIDDEN",
+  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
+  NOT_FOUND: "NOT_FOUND",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+export type ErrorExtensions = {
+  code: ErrorCode;
+  details?: Record<string, unknown>;
+  field?: string;
+};
+
+export abstract class BaseGraphQLException extends GraphQLError {
+  constructor(
+    message: string,
+    public readonly code: ErrorCode,
+    extensions?: Omit<ErrorExtensions, "code">
+  ) {
+    const options: GraphQLErrorOptions = {
+      extensions: {
+        code,
+        ...extensions,
+      },
+    };
+    super(message, options);
+  }
+}

--- a/src/backend/src/common/exception/forbidden.exception.spec.ts
+++ b/src/backend/src/common/exception/forbidden.exception.spec.ts
@@ -1,0 +1,16 @@
+import { ForbiddenException } from "./forbidden.exception";
+
+describe("ForbiddenException", () => {
+  it("기본 메시지로 생성", () => {
+    const exception = new ForbiddenException();
+
+    expect(exception.message).toBe("접근 권한이 없습니다.");
+    expect(exception.code).toBe("FORBIDDEN");
+  });
+
+  it("커스텀 메시지로 생성", () => {
+    const exception = new ForbiddenException("관리자만 접근 가능합니다.");
+
+    expect(exception.message).toBe("관리자만 접근 가능합니다.");
+  });
+});

--- a/src/backend/src/common/exception/forbidden.exception.ts
+++ b/src/backend/src/common/exception/forbidden.exception.ts
@@ -1,0 +1,7 @@
+import { BaseGraphQLException, ERROR_CODES } from "./base.exception";
+
+export class ForbiddenException extends BaseGraphQLException {
+  constructor(message = "접근 권한이 없습니다.") {
+    super(message, ERROR_CODES.FORBIDDEN);
+  }
+}

--- a/src/backend/src/common/exception/index.ts
+++ b/src/backend/src/common/exception/index.ts
@@ -1,0 +1,5 @@
+export * from "./base.exception";
+export * from "./forbidden.exception";
+export * from "./not-found.exception";
+export * from "./unauthorized.exception";
+export * from "./validation.exception";

--- a/src/backend/src/common/exception/not-found.exception.spec.ts
+++ b/src/backend/src/common/exception/not-found.exception.spec.ts
@@ -1,0 +1,22 @@
+import { NotFoundException } from "./not-found.exception";
+
+describe("NotFoundException", () => {
+  it("리소스명만으로 생성", () => {
+    const exception = new NotFoundException("Content");
+
+    expect(exception.message).toBe("Content을(를) 찾을 수 없습니다.");
+    expect(exception.code).toBe("NOT_FOUND");
+  });
+
+  it("리소스명과 ID로 생성", () => {
+    const exception = new NotFoundException("Content", 123);
+
+    expect(exception.message).toBe("Content(id: 123)을(를) 찾을 수 없습니다.");
+  });
+
+  it("문자열 ID 지원", () => {
+    const exception = new NotFoundException("User", "abc-123");
+
+    expect(exception.message).toBe("User(id: abc-123)을(를) 찾을 수 없습니다.");
+  });
+});

--- a/src/backend/src/common/exception/not-found.exception.ts
+++ b/src/backend/src/common/exception/not-found.exception.ts
@@ -1,0 +1,10 @@
+import { BaseGraphQLException, ERROR_CODES } from "./base.exception";
+
+export class NotFoundException extends BaseGraphQLException {
+  constructor(resource: string, id?: number | string) {
+    const message = id
+      ? `${resource}(id: ${id})을(를) 찾을 수 없습니다.`
+      : `${resource}을(를) 찾을 수 없습니다.`;
+    super(message, ERROR_CODES.NOT_FOUND);
+  }
+}

--- a/src/backend/src/common/exception/unauthorized.exception.spec.ts
+++ b/src/backend/src/common/exception/unauthorized.exception.spec.ts
@@ -1,0 +1,16 @@
+import { UnauthorizedException } from "./unauthorized.exception";
+
+describe("UnauthorizedException", () => {
+  it("기본 메시지로 생성", () => {
+    const exception = new UnauthorizedException();
+
+    expect(exception.message).toBe("인증이 필요합니다.");
+    expect(exception.code).toBe("UNAUTHORIZED");
+  });
+
+  it("커스텀 메시지로 생성", () => {
+    const exception = new UnauthorizedException("세션이 만료되었습니다.");
+
+    expect(exception.message).toBe("세션이 만료되었습니다.");
+  });
+});

--- a/src/backend/src/common/exception/unauthorized.exception.ts
+++ b/src/backend/src/common/exception/unauthorized.exception.ts
@@ -1,0 +1,7 @@
+import { BaseGraphQLException, ERROR_CODES } from "./base.exception";
+
+export class UnauthorizedException extends BaseGraphQLException {
+  constructor(message = "인증이 필요합니다.") {
+    super(message, ERROR_CODES.UNAUTHORIZED);
+  }
+}

--- a/src/backend/src/common/exception/validation.exception.spec.ts
+++ b/src/backend/src/common/exception/validation.exception.spec.ts
@@ -1,0 +1,24 @@
+import { ValidationException } from "./validation.exception";
+
+describe("ValidationException", () => {
+  it("기본 메시지와 VALIDATION_ERROR 코드 포함", () => {
+    const exception = new ValidationException("잘못된 입력입니다.");
+
+    expect(exception.message).toBe("잘못된 입력입니다.");
+    expect(exception.code).toBe("VALIDATION_ERROR");
+    expect(exception.extensions?.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("필드 정보 포함", () => {
+    const exception = new ValidationException("초는 60초 미만이어야 합니다.", "seconds");
+
+    expect(exception.message).toBe("초는 60초 미만이어야 합니다.");
+    expect(exception.extensions?.field).toBe("seconds");
+  });
+
+  it("필드 없이 생성 가능", () => {
+    const exception = new ValidationException("유효하지 않은 값입니다.");
+
+    expect(exception.extensions?.field).toBeUndefined();
+  });
+});

--- a/src/backend/src/common/exception/validation.exception.ts
+++ b/src/backend/src/common/exception/validation.exception.ts
@@ -1,0 +1,7 @@
+import { BaseGraphQLException, ERROR_CODES } from "./base.exception";
+
+export class ValidationException extends BaseGraphQLException {
+  constructor(message: string, field?: string) {
+    super(message, ERROR_CODES.VALIDATION_ERROR, { field });
+  }
+}

--- a/src/backend/src/common/filter/all-exceptions.filter.spec.ts
+++ b/src/backend/src/common/filter/all-exceptions.filter.spec.ts
@@ -1,0 +1,125 @@
+import { ArgumentsHost, HttpStatus, NotFoundException } from "@nestjs/common";
+import { ClsService } from "nestjs-cls";
+
+import { NotFoundException as CustomNotFoundException } from "../exception";
+import { AllExceptionsFilter } from "./all-exceptions.filter";
+
+describe("AllExceptionsFilter", () => {
+  let filter: AllExceptionsFilter;
+  let mockClsService: jest.Mocked<ClsService>;
+  let mockResponse: {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+  let mockRequest: {
+    method: string;
+    url: string;
+  };
+  let mockHost: ArgumentsHost;
+
+  beforeEach(() => {
+    mockClsService = {
+      getId: jest.fn().mockReturnValue("test-correlation-id"),
+    } as unknown as jest.Mocked<ClsService>;
+    filter = new AllExceptionsFilter(mockClsService);
+    mockResponse = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    mockRequest = {
+      method: "GET",
+      url: "/api/test",
+    };
+    mockHost = {
+      getType: jest.fn().mockReturnValue("http"),
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: () => mockRequest,
+        getResponse: () => mockResponse,
+      }),
+    } as unknown as ArgumentsHost;
+  });
+
+  it("GraphQL 요청은 re-throw", () => {
+    const graphqlHost = {
+      getType: jest.fn().mockReturnValue("graphql"),
+    } as unknown as ArgumentsHost;
+    const exception = new Error("Test error");
+
+    expect(() => filter.catch(exception, graphqlHost)).toThrow(exception);
+  });
+
+  it("HttpException 처리", () => {
+    const exception = new NotFoundException("리소스를 찾을 수 없습니다.");
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "test-correlation-id",
+        error: "NOT_FOUND",
+        message: "리소스를 찾을 수 없습니다.",
+        path: "/api/test",
+        statusCode: 404,
+      })
+    );
+  });
+
+  it("일반 Error 처리", () => {
+    const exception = new Error("Something went wrong");
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "test-correlation-id",
+        error: "INTERNAL_SERVER_ERROR",
+        statusCode: 500,
+      })
+    );
+  });
+
+  it("알 수 없는 타입 처리", () => {
+    filter.catch("unknown error", mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "test-correlation-id",
+        error: "INTERNAL_SERVER_ERROR",
+        message: "Internal server error",
+        statusCode: 500,
+      })
+    );
+  });
+
+  it("correlationId 포함 확인", () => {
+    const exception = new Error("Test error");
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "test-correlation-id",
+        timestamp: expect.any(String),
+      })
+    );
+  });
+
+  it("BaseGraphQLException 처리 - NOT_FOUND", () => {
+    const exception = new CustomNotFoundException("Content", "123");
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "test-correlation-id",
+        error: "NOT_FOUND",
+        message: "Content(id: 123)을(를) 찾을 수 없습니다.",
+        statusCode: 404,
+      })
+    );
+  });
+});

--- a/src/backend/src/common/filter/all-exceptions.filter.ts
+++ b/src/backend/src/common/filter/all-exceptions.filter.ts
@@ -1,0 +1,75 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+} from "@nestjs/common";
+import { GqlContextType } from "@nestjs/graphql";
+import { Request, Response } from "express";
+import { ClsService } from "nestjs-cls";
+
+import { NODE_ENV } from "../constants/env.constants";
+import { BaseGraphQLException, ERROR_CODES, ErrorCode } from "../exception";
+import { ErrorResponse } from "./types";
+
+@Injectable()
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly codeToStatusMap: Record<ErrorCode, HttpStatus> = {
+    [ERROR_CODES.BAD_REQUEST]: HttpStatus.BAD_REQUEST,
+    [ERROR_CODES.FORBIDDEN]: HttpStatus.FORBIDDEN,
+    [ERROR_CODES.INTERNAL_SERVER_ERROR]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [ERROR_CODES.NOT_FOUND]: HttpStatus.NOT_FOUND,
+    [ERROR_CODES.UNAUTHORIZED]: HttpStatus.UNAUTHORIZED,
+    [ERROR_CODES.VALIDATION_ERROR]: HttpStatus.BAD_REQUEST,
+  };
+
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  constructor(private readonly cls: ClsService) {}
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    if (host.getType<GqlContextType>() === "graphql") {
+      throw exception;
+    }
+
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+    const correlationId = this.cls.getId();
+    const isProduction = process.env.NODE_ENV === NODE_ENV.PRODUCTION;
+
+    let message = "Internal server error";
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+    if (exception instanceof BaseGraphQLException) {
+      status = this.codeToStatusMap[exception.code] ?? HttpStatus.INTERNAL_SERVER_ERROR;
+      message = exception.message;
+    } else if (exception instanceof HttpException) {
+      message = exception.message;
+      status = exception.getStatus();
+    } else if (exception instanceof Error) {
+      this.logger.error(
+        `[${correlationId}] Unhandled exception: ${exception.message}`,
+        exception.stack
+      );
+      message = isProduction ? "Internal server error" : exception.message;
+    } else {
+      this.logger.error(`[${correlationId}] Unknown exception type: ${String(exception)}`);
+    }
+
+    const errorResponse: ErrorResponse = {
+      correlationId,
+      error: HttpStatus[status] || "Unknown Error",
+      message,
+      path: request.url,
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+    };
+
+    response.status(status).json(errorResponse);
+  }
+}

--- a/src/backend/src/common/filter/graphql-format-error.spec.ts
+++ b/src/backend/src/common/filter/graphql-format-error.spec.ts
@@ -1,0 +1,82 @@
+import { GraphQLFormattedError } from "graphql";
+import { ClsServiceManager } from "nestjs-cls";
+
+import { ERROR_CODES } from "../exception";
+import { formatGraphQLError } from "./graphql-format-error";
+
+jest.mock("nestjs-cls", () => ({
+  ClsServiceManager: {
+    getClsService: jest.fn(),
+  },
+}));
+
+describe("formatGraphQLError", () => {
+  const mockClsService = {
+    getId: jest.fn().mockReturnValue("test-correlation-id"),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ClsServiceManager.getClsService as jest.Mock).mockReturnValue(mockClsService);
+    delete process.env.NODE_ENV;
+  });
+
+  it("모든 에러에 correlationId 추가", () => {
+    const formattedError: GraphQLFormattedError = {
+      extensions: { code: "VALIDATION_ERROR", field: "field" },
+      message: "잘못된 입력",
+    };
+
+    const result = formatGraphQLError(formattedError);
+
+    expect(result.extensions?.correlationId).toBe("test-correlation-id");
+    expect(result.extensions?.code).toBe("VALIDATION_ERROR");
+    expect(result.message).toBe("잘못된 입력");
+  });
+
+  it("프로덕션에서 INTERNAL_SERVER_ERROR는 마스킹", () => {
+    process.env.NODE_ENV = "production";
+    const formattedError: GraphQLFormattedError = {
+      extensions: {
+        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        stacktrace: ["sensitive"],
+      },
+      message: "Sensitive error details",
+    };
+
+    const result = formatGraphQLError(formattedError);
+
+    expect(result.message).toBe("Internal server error");
+    expect(result.extensions?.correlationId).toBe("test-correlation-id");
+    expect(result.extensions?.stacktrace).toBeUndefined();
+  });
+
+  it("개발 환경에서 INTERNAL_SERVER_ERROR는 그대로 노출", () => {
+    process.env.NODE_ENV = "development";
+    const formattedError: GraphQLFormattedError = {
+      extensions: {
+        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        stacktrace: ["trace"],
+      },
+      message: "Detailed error",
+    };
+
+    const result = formatGraphQLError(formattedError);
+
+    expect(result.message).toBe("Detailed error");
+    expect(result.extensions?.stacktrace).toEqual(["trace"]);
+    expect(result.extensions?.correlationId).toBe("test-correlation-id");
+  });
+
+  it("CLS 서비스 없을 때 correlationId는 undefined", () => {
+    (ClsServiceManager.getClsService as jest.Mock).mockReturnValue(undefined);
+    const formattedError: GraphQLFormattedError = {
+      extensions: { code: "SOME_ERROR" },
+      message: "Error",
+    };
+
+    const result = formatGraphQLError(formattedError);
+
+    expect(result.extensions?.correlationId).toBeUndefined();
+  });
+});

--- a/src/backend/src/common/filter/graphql-format-error.ts
+++ b/src/backend/src/common/filter/graphql-format-error.ts
@@ -1,0 +1,33 @@
+import { GraphQLFormattedError } from "graphql";
+import { ClsServiceManager } from "nestjs-cls";
+
+import { NODE_ENV } from "../constants/env.constants";
+import { ERROR_CODES } from "../exception";
+
+export const formatGraphQLError = (
+  formattedError: GraphQLFormattedError
+): GraphQLFormattedError => {
+  const cls = ClsServiceManager.getClsService();
+  const correlationId = cls?.getId();
+  const isProduction = process.env.NODE_ENV === NODE_ENV.PRODUCTION;
+
+  const code = formattedError.extensions?.code;
+
+  if (isProduction && code === ERROR_CODES.INTERNAL_SERVER_ERROR) {
+    return {
+      extensions: {
+        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        correlationId,
+      },
+      message: "Internal server error",
+    };
+  }
+
+  return {
+    ...formattedError,
+    extensions: {
+      ...formattedError.extensions,
+      correlationId,
+    },
+  };
+};

--- a/src/backend/src/common/filter/index.ts
+++ b/src/backend/src/common/filter/index.ts
@@ -1,0 +1,3 @@
+export * from "./all-exceptions.filter";
+export * from "./graphql-format-error";
+export * from "./types";

--- a/src/backend/src/common/filter/types.ts
+++ b/src/backend/src/common/filter/types.ts
@@ -1,0 +1,8 @@
+export type ErrorResponse = {
+  correlationId?: string;
+  error: string;
+  message: string;
+  path: string;
+  statusCode: number;
+  timestamp: string;
+};


### PR DESCRIPTION
GraphQL/HTTP 요청에 대한 일관된 에러 처리 시스템 구현

- 커스텀 예외 클래스: NotFoundException, ForbiddenException, UnauthorizedException, ValidationException
- AllExceptionsFilter: HTTP 요청 전역 에러 처리
- formatGraphQLError: GraphQL 에러 포맷팅 및 correlationId 주입
- nestjs-cls: 요청별 UUID 기반 추적 컨텍스트
- 프로덕션 환경에서 debug/playground 비활성화

fix #192