### PR TITLE
refactor(backend): Mutation InputType을 별도 DTO 파일로 분리

### DIFF
--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -50,27 +50,49 @@ type ContentCategory {
 }
 
 input ContentCreateInput {
+  """컨텐츠 카테고리 ID"""
   categoryId: Int!
-  contentRewards: [ContentCreateItemsInput!]!
-  contentSeeMoreRewards: [ContentCreateSeeMoreRewardsInput!]
+
+  """컨텐츠 보상 목록"""
+  contentRewards: [ContentCreateItemInput!]!
+
+  """더보기 컨텐츠 보상 목록"""
+  contentSeeMoreRewards: [ContentCreateSeeMoreRewardInput!]
+
+  """소요 시간 (초 단위)"""
   duration: Int!
+
+  """관문"""
   gate: Int
+
+  """레벨"""
   level: Int!
+
+  """이름"""
   name: String!
 }
 
-input ContentCreateItemsInput {
+input ContentCreateItemInput {
+  """평균 획득 수량"""
   averageQuantity: Float!
+
+  """귀속 여부"""
   isBound: Boolean!
+
+  """아이템 ID"""
   itemId: Int!
 }
 
 type ContentCreateResult {
+  """성공 여부"""
   ok: Boolean!
 }
 
-input ContentCreateSeeMoreRewardsInput {
+input ContentCreateSeeMoreRewardInput {
+  """아이템 ID"""
   itemId: Int!
+
+  """수량"""
   quantity: Float!
 }
 
@@ -84,26 +106,28 @@ type ContentDuration {
 }
 
 input ContentDurationEditInput {
+  """컨텐츠 ID"""
   contentId: Int!
+
+  """분"""
   minutes: Int!
+
+  """초"""
   seconds: Int!
 }
 
 type ContentDurationEditResult {
+  """성공 여부"""
   ok: Boolean!
 }
 
 input ContentDurationsEditInput {
-  contentDurations: [ContentDurationsEditInputDuration!]!
-}
-
-input ContentDurationsEditInputDuration {
-  contentId: Int!
-  minutes: Int!
-  seconds: Int!
+  """컨텐츠 소요 시간 목록"""
+  contentDurations: [ContentDurationEditInput!]!
 }
 
 type ContentDurationsEditResult {
+  """성공 여부"""
   ok: Boolean!
 }
 
@@ -162,9 +186,16 @@ type ContentReward {
 }
 
 input ContentRewardEditInput {
+  """평균 획득 수량"""
   averageQuantity: Float!
+
+  """컨텐츠 ID"""
   contentId: Int!
+
+  """거래 가능 여부"""
   isSellable: Boolean!
+
+  """아이템 ID"""
   itemId: Int!
 }
 
@@ -174,11 +205,15 @@ input ContentRewardReportInput {
 }
 
 input ContentRewardsEditInput {
+  """컨텐츠 보상 목록"""
   contentRewards: [ContentRewardEditInput!]!
+
+  """제보 가능 여부"""
   isReportable: Boolean!
 }
 
 type ContentRewardsEditResult {
+  """성공 여부"""
   ok: Boolean!
 }
 
@@ -201,16 +236,23 @@ type ContentSeeMoreReward {
 }
 
 input ContentSeeMoreRewardEditInput {
+  """컨텐츠 ID"""
   contentId: Int!
+
+  """아이템 ID"""
   itemId: Int!
+
+  """수량"""
   quantity: Float!
 }
 
 input ContentSeeMoreRewardsEditInput {
+  """더보기 컨텐츠 보상 목록"""
   contentSeeMoreRewards: [ContentSeeMoreRewardEditInput!]!
 }
 
 type ContentSeeMoreRewardsEditResult {
+  """성공 여부"""
   ok: Boolean!
 }
 
@@ -247,20 +289,35 @@ input ContentsFilter {
 }
 
 input CustomContentWageCalculateInput {
-  items: [CustomContentWageCalculateItemsInput!]!
+  """아이템 목록"""
+  items: [CustomContentWageCalculateItemInput!]!
+
+  """분"""
   minutes: Int!
+
+  """초"""
   seconds: Int!
 }
 
-input CustomContentWageCalculateItemsInput {
+input CustomContentWageCalculateItemInput {
+  """아이템 ID"""
   id: Int!
+
+  """수량"""
   quantity: Float!
 }
 
 type CustomContentWageCalculateResult {
+  """클리어당 골드 획득량"""
   goldAmountPerClear: Int!
+
+  """시간당 골드 획득량"""
   goldAmountPerHour: Int!
+
+  """시간당 원화 환산 금액"""
   krwAmountPerHour: Int!
+
+  """성공 여부"""
   ok: Boolean!
 }
 
@@ -386,11 +443,15 @@ type UserItem {
 }
 
 input UserItemPriceEditInput {
+  """아이템 ID"""
   id: Int!
+
+  """가격"""
   price: Float!
 }
 
 type UserItemPriceEditResult {
+  """성공 여부"""
   ok: Boolean!
 }
 

--- a/src/backend/src/content/dto/content-duration.dto.ts
+++ b/src/backend/src/content/dto/content-duration.dto.ts
@@ -1,0 +1,33 @@
+import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class ContentDurationEditInput {
+  @Field({ description: "컨텐츠 ID" })
+  contentId: number;
+
+  @Field(() => Int, { description: "분" })
+  minutes: number;
+
+  @Field(() => Int, { description: "초" })
+  seconds: number;
+}
+
+@ObjectType()
+export class ContentDurationEditResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}
+
+@InputType()
+export class ContentDurationsEditInput {
+  @Field(() => [ContentDurationEditInput], {
+    description: "컨텐츠 소요 시간 목록",
+  })
+  contentDurations: ContentDurationEditInput[];
+}
+
+@ObjectType()
+export class ContentDurationsEditResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/dto/content-reward.dto.ts
+++ b/src/backend/src/content/dto/content-reward.dto.ts
@@ -1,0 +1,31 @@
+import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class ContentRewardEditInput {
+  @Field(() => Float, { description: "평균 획득 수량" })
+  averageQuantity: number;
+
+  @Field({ description: "컨텐츠 ID" })
+  contentId: number;
+
+  @Field(() => Boolean, { description: "거래 가능 여부" })
+  isSellable: boolean;
+
+  @Field({ description: "아이템 ID" })
+  itemId: number;
+}
+
+@InputType()
+export class ContentRewardsEditInput {
+  @Field(() => [ContentRewardEditInput], { description: "컨텐츠 보상 목록" })
+  contentRewards: ContentRewardEditInput[];
+
+  @Field({ description: "제보 가능 여부" })
+  isReportable: boolean;
+}
+
+@ObjectType()
+export class ContentRewardsEditResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/dto/content-see-more-reward.dto.ts
+++ b/src/backend/src/content/dto/content-see-more-reward.dto.ts
@@ -1,0 +1,27 @@
+import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class ContentSeeMoreRewardEditInput {
+  @Field({ description: "컨텐츠 ID" })
+  contentId: number;
+
+  @Field({ description: "아이템 ID" })
+  itemId: number;
+
+  @Field(() => Float, { description: "수량" })
+  quantity: number;
+}
+
+@InputType()
+export class ContentSeeMoreRewardsEditInput {
+  @Field(() => [ContentSeeMoreRewardEditInput], {
+    description: "더보기 컨텐츠 보상 목록",
+  })
+  contentSeeMoreRewards: ContentSeeMoreRewardEditInput[];
+}
+
+@ObjectType()
+export class ContentSeeMoreRewardsEditResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/dto/content-wage.dto.ts
+++ b/src/backend/src/content/dto/content-wage.dto.ts
@@ -1,0 +1,39 @@
+import { Field, Float, InputType, Int, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class CustomContentWageCalculateInput {
+  @Field(() => [CustomContentWageCalculateItemInput], {
+    description: "아이템 목록",
+  })
+  items: CustomContentWageCalculateItemInput[];
+
+  @Field(() => Int, { description: "분" })
+  minutes: number;
+
+  @Field(() => Int, { description: "초" })
+  seconds: number;
+}
+
+@InputType()
+export class CustomContentWageCalculateItemInput {
+  @Field({ description: "아이템 ID" })
+  id: number;
+
+  @Field(() => Float, { description: "수량" })
+  quantity: number;
+}
+
+@ObjectType()
+export class CustomContentWageCalculateResult {
+  @Field({ description: "클리어당 골드 획득량" })
+  goldAmountPerClear: number;
+
+  @Field({ description: "시간당 골드 획득량" })
+  goldAmountPerHour: number;
+
+  @Field({ description: "시간당 원화 환산 금액" })
+  krwAmountPerHour: number;
+
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/dto/content.dto.ts
+++ b/src/backend/src/content/dto/content.dto.ts
@@ -1,0 +1,55 @@
+import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class ContentCreateInput {
+  @Field({ description: "컨텐츠 카테고리 ID" })
+  categoryId: number;
+
+  @Field(() => [ContentCreateItemInput], { description: "컨텐츠 보상 목록" })
+  contentRewards: ContentCreateItemInput[];
+
+  @Field(() => [ContentCreateSeeMoreRewardInput], {
+    description: "더보기 컨텐츠 보상 목록",
+    nullable: true,
+  })
+  contentSeeMoreRewards?: ContentCreateSeeMoreRewardInput[];
+
+  @Field({ description: "소요 시간 (초 단위)" })
+  duration: number;
+
+  @Field({ description: "관문", nullable: true })
+  gate?: number | null;
+
+  @Field({ description: "레벨" })
+  level: number;
+
+  @Field({ description: "이름" })
+  name: string;
+}
+
+@InputType()
+export class ContentCreateItemInput {
+  @Field(() => Float, { description: "평균 획득 수량" })
+  averageQuantity: number;
+
+  @Field({ description: "귀속 여부" })
+  isBound: boolean;
+
+  @Field({ description: "아이템 ID" })
+  itemId: number;
+}
+
+@ObjectType()
+export class ContentCreateResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}
+
+@InputType()
+export class ContentCreateSeeMoreRewardInput {
+  @Field({ description: "아이템 ID" })
+  itemId: number;
+
+  @Field(() => Float, { description: "수량" })
+  quantity: number;
+}

--- a/src/backend/src/content/dto/index.ts
+++ b/src/backend/src/content/dto/index.ts
@@ -1,0 +1,6 @@
+export * from "./content.dto";
+export * from "./content-duration.dto";
+export * from "./content-reward.dto";
+export * from "./content-see-more-reward.dto";
+export * from "./content-wage.dto";
+export * from "./item.dto";

--- a/src/backend/src/content/dto/item.dto.ts
+++ b/src/backend/src/content/dto/item.dto.ts
@@ -1,0 +1,16 @@
+import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+
+@InputType()
+export class UserItemPriceEditInput {
+  @Field({ description: "아이템 ID" })
+  id: number;
+
+  @Field(() => Float, { description: "가격" })
+  price: number;
+}
+
+@ObjectType()
+export class UserItemPriceEditResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/mutation/content-create.mutation.ts
+++ b/src/backend/src/content/mutation/content-create.mutation.ts
@@ -1,58 +1,8 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, Float, InputType, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
 import { AuthGuard } from "src/auth/auth.guard";
 import { PrismaService } from "src/prisma";
-
-@InputType()
-export class ContentCreateInput {
-  @Field()
-  categoryId: number;
-
-  @Field(() => [ContentCreateItemsInput])
-  contentRewards: ContentCreateItemsInput[];
-
-  @Field(() => [ContentCreateSeeMoreRewardsInput], { nullable: true })
-  contentSeeMoreRewards?: ContentCreateSeeMoreRewardsInput[];
-
-  @Field()
-  duration: number;
-
-  @Field({ nullable: true })
-  gate?: number | null;
-
-  @Field()
-  level: number;
-
-  @Field()
-  name: string;
-}
-
-@InputType()
-export class ContentCreateItemsInput {
-  @Field(() => Float)
-  averageQuantity: number;
-
-  @Field()
-  isBound: boolean;
-
-  @Field()
-  itemId: number;
-}
-
-@InputType()
-export class ContentCreateSeeMoreRewardsInput {
-  @Field()
-  itemId: number;
-
-  @Field(() => Float)
-  quantity: number;
-}
-
-@ObjectType()
-class ContentCreateResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
+import { ContentCreateInput, ContentCreateResult } from "../dto";
 
 @Resolver()
 export class ContentCreateMutation {

--- a/src/backend/src/content/mutation/content-duration-edit.mutation.ts
+++ b/src/backend/src/content/mutation/content-duration-edit.mutation.ts
@@ -1,29 +1,12 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, InputType, Int, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { UserRole } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
-import { PrismaService } from "src/prisma";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
-import { UserRole } from "@prisma/client";
+import { PrismaService } from "src/prisma";
+import { ContentDurationEditInput, ContentDurationEditResult } from "../dto";
 import { ContentDurationService } from "../service/content-duration.service";
-
-@InputType()
-class ContentDurationEditInput {
-  @Field()
-  contentId: number;
-
-  @Field(() => Int)
-  minutes: number;
-
-  @Field(() => Int)
-  seconds: number;
-}
-
-@ObjectType()
-class ContentDurationEditResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
 
 @Resolver()
 export class ContentDurationEditMutation {

--- a/src/backend/src/content/mutation/content-durations-edit.mutation.ts
+++ b/src/backend/src/content/mutation/content-durations-edit.mutation.ts
@@ -1,35 +1,12 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, InputType, Int, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { UserRole } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
-import { PrismaService } from "src/prisma";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
-import { UserRole } from "@prisma/client";
+import { PrismaService } from "src/prisma";
+import { ContentDurationsEditInput, ContentDurationsEditResult } from "../dto";
 import { ContentDurationService } from "../service/content-duration.service";
-
-@InputType()
-class ContentDurationsEditInputDuration {
-  @Field()
-  contentId: number;
-
-  @Field(() => Int)
-  minutes: number;
-
-  @Field(() => Int)
-  seconds: number;
-}
-
-@InputType()
-class ContentDurationsEditInput {
-  @Field(() => [ContentDurationsEditInputDuration])
-  contentDurations: ContentDurationsEditInputDuration[];
-}
-
-@ObjectType()
-class ContentDurationsEditResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
 
 @Resolver()
 export class ContentDurationsEditMutation {

--- a/src/backend/src/content/mutation/content-rewards-edit.mutation.ts
+++ b/src/backend/src/content/mutation/content-rewards-edit.mutation.ts
@@ -1,40 +1,11 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, Float, InputType, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { UserRole } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
-import { PrismaService } from "src/prisma";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
-import { UserRole } from "@prisma/client";
-
-@InputType()
-class ContentRewardEditInput {
-  @Field(() => Float)
-  averageQuantity: number;
-
-  @Field()
-  contentId: number;
-
-  @Field(() => Boolean)
-  isSellable: boolean;
-
-  @Field()
-  itemId: number;
-}
-
-@InputType()
-export class ContentRewardsEditInput {
-  @Field(() => [ContentRewardEditInput])
-  contentRewards: ContentRewardEditInput[];
-
-  @Field()
-  isReportable: boolean;
-}
-
-@ObjectType()
-class ContentRewardsEditResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
+import { PrismaService } from "src/prisma";
+import { ContentRewardsEditInput, ContentRewardsEditResult } from "../dto";
 
 @Resolver()
 export class ContentRewardsEditMutation {

--- a/src/backend/src/content/mutation/content-see-more-rewards-edit.mutation.ts
+++ b/src/backend/src/content/mutation/content-see-more-rewards-edit.mutation.ts
@@ -1,34 +1,11 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, Float, InputType, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { UserRole } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
-import { PrismaService } from "src/prisma";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
-import { UserRole } from "@prisma/client";
-
-@InputType()
-class ContentSeeMoreRewardEditInput {
-  @Field()
-  contentId: number;
-
-  @Field()
-  itemId: number;
-
-  @Field(() => Float)
-  quantity: number;
-}
-
-@InputType()
-export class ContentSeeMoreRewardsEditInput {
-  @Field(() => [ContentSeeMoreRewardEditInput])
-  contentSeeMoreRewards: ContentSeeMoreRewardEditInput[];
-}
-
-@ObjectType()
-class ContentSeeMoreRewardsEditResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
+import { PrismaService } from "src/prisma";
+import { ContentSeeMoreRewardsEditInput, ContentSeeMoreRewardsEditResult } from "../dto";
 
 @Resolver()
 export class ContentSeeMoreRewardsEditMutation {

--- a/src/backend/src/content/mutation/custom-content-wage-calculate.mutation.ts
+++ b/src/backend/src/content/mutation/custom-content-wage-calculate.mutation.ts
@@ -1,51 +1,7 @@
-import {
-  Args,
-  Field,
-  Float,
-  InputType,
-  Int,
-  Mutation,
-  ObjectType,
-  Resolver,
-} from "@nestjs/graphql";
-import { ContentWageService } from "../service/content-wage.service";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { CustomContentWageCalculateInput, CustomContentWageCalculateResult } from "../dto";
 import { ContentDurationService } from "../service/content-duration.service";
-
-@InputType()
-class CustomContentWageCalculateInput {
-  @Field(() => [CustomContentWageCalculateItemsInput])
-  items: CustomContentWageCalculateItemsInput[];
-
-  @Field(() => Int)
-  minutes: number;
-
-  @Field(() => Int)
-  seconds: number;
-}
-
-@InputType()
-class CustomContentWageCalculateItemsInput {
-  @Field()
-  id: number;
-
-  @Field(() => Float)
-  quantity: number;
-}
-
-@ObjectType()
-class CustomContentWageCalculateResult {
-  @Field()
-  goldAmountPerClear: number;
-
-  @Field()
-  goldAmountPerHour: number;
-
-  @Field()
-  krwAmountPerHour: number;
-
-  @Field(() => Boolean)
-  ok: boolean;
-}
+import { ContentWageService } from "../service/content-wage.service";
 
 @Resolver()
 export class CustomContentWageCalculateMutation {

--- a/src/backend/src/content/mutation/user-item-price-edit.mutation.ts
+++ b/src/backend/src/content/mutation/user-item-price-edit.mutation.ts
@@ -1,23 +1,9 @@
 import { UseGuards } from "@nestjs/common";
-import { Args, Field, Float, InputType, Mutation, ObjectType, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
 import { AuthGuard } from "src/auth/auth.guard";
 import { PrismaService } from "src/prisma";
 import { UserContentService } from "../../user/service/user-content.service";
-
-@InputType()
-class UserItemPriceEditInput {
-  @Field()
-  id: number;
-
-  @Field(() => Float)
-  price: number;
-}
-
-@ObjectType()
-class UserItemPriceEditResult {
-  @Field(() => Boolean)
-  ok: boolean;
-}
+import { UserItemPriceEditInput, UserItemPriceEditResult } from "../dto";
 
 @Resolver()
 export class UserItemPriceEditMutation {

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -74,15 +74,15 @@ export type ContentCategory = {
 
 export type ContentCreateInput = {
   categoryId: Scalars['Int']['input'];
-  contentRewards: Array<ContentCreateItemsInput>;
-  contentSeeMoreRewards?: InputMaybe<Array<ContentCreateSeeMoreRewardsInput>>;
+  contentRewards: Array<ContentCreateItemInput>;
+  contentSeeMoreRewards?: InputMaybe<Array<ContentCreateSeeMoreRewardInput>>;
   duration: Scalars['Int']['input'];
   gate?: InputMaybe<Scalars['Int']['input']>;
   level: Scalars['Int']['input'];
   name: Scalars['String']['input'];
 };
 
-export type ContentCreateItemsInput = {
+export type ContentCreateItemInput = {
   averageQuantity: Scalars['Float']['input'];
   isBound: Scalars['Boolean']['input'];
   itemId: Scalars['Int']['input'];
@@ -93,7 +93,7 @@ export type ContentCreateResult = {
   ok: Scalars['Boolean']['output'];
 };
 
-export type ContentCreateSeeMoreRewardsInput = {
+export type ContentCreateSeeMoreRewardInput = {
   itemId: Scalars['Int']['input'];
   quantity: Scalars['Float']['input'];
 };
@@ -120,10 +120,10 @@ export type ContentDurationEditResult = {
 };
 
 export type ContentDurationsEditInput = {
-  contentDurations: Array<ContentDurationsEditInputDuration>;
+  contentDurations: Array<ContentDurationsEditInputItem>;
 };
 
-export type ContentDurationsEditInputDuration = {
+export type ContentDurationsEditInputItem = {
   contentId: Scalars['Int']['input'];
   minutes: Scalars['Int']['input'];
   seconds: Scalars['Int']['input'];
@@ -283,12 +283,12 @@ export type ContentsFilter = {
 };
 
 export type CustomContentWageCalculateInput = {
-  items: Array<CustomContentWageCalculateItemsInput>;
+  items: Array<CustomContentWageCalculateItemInput>;
   minutes: Scalars['Int']['input'];
   seconds: Scalars['Int']['input'];
 };
 
-export type CustomContentWageCalculateItemsInput = {
+export type CustomContentWageCalculateItemInput = {
   id: Scalars['Int']['input'];
   quantity: Scalars['Float']['input'];
 };


### PR DESCRIPTION
Mutation 파일 내부에 정의된 InputType/ObjectType을 도메인별 DTO 파일로 추출하여 관심사 분리 및 재사용성 향상

- content/dto/ 디렉토리 생성 및 6개 DTO 파일 추가
- 7개 mutation 파일에서 타입 정의 제거 후 DTO import로 변경
- 네스티드 InputType 명명 표준화 (복수형 → 단수형)
- GraphQL 스키마 타입명 일관성 개선

fix #194