### PR TITLE
refactor(backend): Relay 페이지네이션 및 Mutation 응답 표준 인프라 구축

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -37,6 +37,7 @@
     "dataloader": "2.2.3",
     "dayjs": "1.11.13",
     "discord-webhook-node": "1.1.8",
+    "es-toolkit": "1.42.0",
     "express-session": "1.18.1",
     "graphql": "16.9.0",
     "lodash": "4.17.21",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       discord-webhook-node:
         specifier: 1.1.8
         version: 1.1.8
+      es-toolkit:
+        specifier: 1.42.0
+        version: 1.42.0
       express-session:
         specifier: 1.18.1
         version: 1.18.1
@@ -3314,6 +3317,12 @@ packages:
         integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
       }
     engines: { node: ">= 0.4" }
+
+  es-toolkit@1.42.0:
+    resolution:
+      {
+        integrity: sha512-SLHIyY7VfDJBM8clz4+T2oquwTQxEzu263AyhVK4jREOAwJ+8eebaa4wM3nlvnAqhDrMm2EsA6hWHaQsMPQ1nA==,
+      }
 
   esbuild-register@3.6.0:
     resolution:
@@ -8622,6 +8631,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.42.0: {}
 
   esbuild-register@3.6.0(esbuild@0.27.0):
     dependencies:

--- a/src/backend/src/common/dto/mutation-result.dto.ts
+++ b/src/backend/src/common/dto/mutation-result.dto.ts
@@ -1,0 +1,22 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class FieldError {
+  @Field(() => String, { description: "Field with error" })
+  field: string;
+
+  @Field(() => String, { description: "Error message" })
+  message: string;
+}
+
+@ObjectType()
+export class MutationResult {
+  @Field(() => [FieldError], { description: "Field-level errors", nullable: true })
+  errors?: FieldError[];
+
+  @Field(() => String, { description: "Message", nullable: true })
+  message?: string;
+
+  @Field(() => Boolean, { description: "Success status" })
+  success: boolean;
+}

--- a/src/backend/src/common/pagination/helpers.spec.ts
+++ b/src/backend/src/common/pagination/helpers.spec.ts
@@ -1,0 +1,118 @@
+import { createPageInfo, decodeCursor, encodeCursor } from "./helpers";
+
+describe("Pagination Helpers", () => {
+  describe("encodeCursor", () => {
+    it("ID를 base64 커서로 인코딩", () => {
+      const cursor = encodeCursor(123);
+      expect(cursor).toBe(Buffer.from("cursor:123").toString("base64"));
+    });
+  });
+
+  describe("decodeCursor", () => {
+    it("base64 커서를 ID로 디코딩", () => {
+      const cursor = Buffer.from("cursor:456").toString("base64");
+      const id = decodeCursor(cursor);
+      expect(id).toBe(456);
+    });
+
+    it("encodeCursor로 인코딩한 커서를 디코딩하면 원본 ID 반환", () => {
+      const originalId = 789;
+      const cursor = encodeCursor(originalId);
+      const decodedId = decodeCursor(cursor);
+      expect(decodedId).toBe(originalId);
+    });
+
+    it("잘못된 커서 포맷인 경우 에러 발생", () => {
+      const invalidCursor = Buffer.from("invalid").toString("base64");
+      expect(() => decodeCursor(invalidCursor)).toThrow("Invalid cursor format");
+    });
+
+    it("커서 ID가 숫자가 아닌 경우 에러 발생", () => {
+      const invalidCursor = Buffer.from("cursor:abc").toString("base64");
+      expect(() => decodeCursor(invalidCursor)).toThrow("Invalid cursor ID");
+    });
+  });
+
+  describe("createPageInfo", () => {
+    it("first + 1개의 아이템이 있을 때 hasNextPage true 반환 및 슬라이싱", () => {
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const result = createPageInfo(items, { first: 3 });
+
+      expect(result.pageInfo.hasNextPage).toBe(true);
+      expect(result.pageInfo.hasPreviousPage).toBe(false);
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes[0].id).toBe(1);
+      expect(result.nodes[2].id).toBe(3);
+      expect(result.pageInfo.startCursor).toBe(encodeCursor(1));
+      expect(result.pageInfo.endCursor).toBe(encodeCursor(3));
+    });
+
+    it("items 길이가 first와 같으면 hasNextPage false 반환", () => {
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      const result = createPageInfo(items, { first: 3 });
+
+      expect(result.pageInfo.hasNextPage).toBe(false);
+      expect(result.pageInfo.hasPreviousPage).toBe(false);
+      expect(result.nodes).toHaveLength(3);
+    });
+
+    it("items 길이가 first보다 작으면 hasNextPage false 반환", () => {
+      const items = [{ id: 1 }, { id: 2 }];
+      const result = createPageInfo(items, { first: 3 });
+
+      expect(result.pageInfo.hasNextPage).toBe(false);
+      expect(result.pageInfo.hasPreviousPage).toBe(false);
+      expect(result.nodes).toHaveLength(2);
+    });
+
+    it("last + 1개의 아이템이 있을 때 hasPreviousPage true 반환 및 슬라이싱", () => {
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const result = createPageInfo(items, { last: 3 });
+
+      expect(result.pageInfo.hasNextPage).toBe(false);
+      expect(result.pageInfo.hasPreviousPage).toBe(true);
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes[0].id).toBe(2);
+      expect(result.nodes[2].id).toBe(4);
+    });
+
+    it("빈 배열인 경우 커서는 undefined 반환", () => {
+      const items: { id: number }[] = [];
+      const result = createPageInfo(items, { first: 10 });
+
+      expect(result.pageInfo.startCursor).toBeUndefined();
+      expect(result.pageInfo.endCursor).toBeUndefined();
+      expect(result.nodes).toHaveLength(0);
+    });
+
+    it("after 커서와 함께 first + 1 페이지네이션 처리", () => {
+      const items = [{ id: 10 }, { id: 11 }, { id: 12 }];
+      const afterCursor = encodeCursor(9);
+      const result = createPageInfo(items, { after: afterCursor, first: 2 });
+
+      expect(result.pageInfo.hasNextPage).toBe(true);
+      expect(result.nodes).toHaveLength(2);
+      expect(result.pageInfo.startCursor).toBe(encodeCursor(10));
+      expect(result.pageInfo.endCursor).toBe(encodeCursor(11));
+    });
+
+    it("first와 last가 함께 주어지면 에러 발생", () => {
+      const items = [{ id: 1 }];
+      expect(() => createPageInfo(items, { first: 1, last: 1 })).toThrow(
+        "Using `first` and `last` arguments together is not supported."
+      );
+    });
+
+    it("after 커서가 있으면 hasPreviousPage가 true여야 합니다", () => {
+      const items = [{ id: 10 }, { id: 11 }];
+      const result = createPageInfo(items, { after: encodeCursor(9), first: 2 });
+      expect(result.pageInfo.hasPreviousPage).toBe(true);
+    });
+
+    it("before 커서가 있으면 hasNextPage가 true여야 합니다", () => {
+      const items = [{ id: 1 }, { id: 2 }];
+      const result = createPageInfo(items, { before: encodeCursor(3), last: 2 });
+      expect(result.pageInfo.hasNextPage).toBe(true);
+    });
+  });
+});

--- a/src/backend/src/common/pagination/helpers.ts
+++ b/src/backend/src/common/pagination/helpers.ts
@@ -1,0 +1,113 @@
+import { drop, last, take } from "es-toolkit";
+
+import { PageInfo } from "./types";
+
+const CURSOR_PREFIX = "cursor";
+const INVALID_CURSOR_FORMAT_MESSAGE = "Invalid cursor format";
+const INVALID_CURSOR_ID_MESSAGE = "Invalid cursor ID";
+const PAGINATION_SIMULTANEOUS_USE_ERROR =
+  "Using `first` and `last` arguments together is not supported.";
+
+export class InvalidCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidCursorError";
+  }
+}
+
+export class PaginationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PaginationError";
+  }
+}
+
+type PaginationArgs = {
+  after?: string;
+  before?: string;
+  first?: number;
+  last?: number;
+};
+
+export const createPageInfo = <T extends { id: number }>(
+  items: T[],
+  args: PaginationArgs
+): { nodes: T[]; pageInfo: PageInfo } => {
+  const { after, before, first, last } = args;
+
+  if (first != null && last != null) {
+    throw new PaginationError(PAGINATION_SIMULTANEOUS_USE_ERROR);
+  }
+
+  if (first != null) {
+    const hasNextPage = items.length > first;
+    const nodes = hasNextPage ? take(items, first) : items;
+    const cursors = createCursors(nodes);
+
+    const pageInfo: PageInfo = {
+      endCursor: cursors.endCursor,
+      hasNextPage,
+      hasPreviousPage: !!after,
+      startCursor: cursors.startCursor,
+    };
+
+    return { nodes, pageInfo };
+  }
+
+  if (last != null) {
+    const hasPreviousPage = items.length > last;
+    const nodes = hasPreviousPage ? drop(items, 1) : items;
+    const cursors = createCursors(nodes);
+
+    const pageInfo: PageInfo = {
+      endCursor: cursors.endCursor,
+      hasNextPage: !!before,
+      hasPreviousPage,
+      startCursor: cursors.startCursor,
+    };
+
+    return { nodes, pageInfo };
+  }
+
+  const cursors = createCursors(items);
+
+  const pageInfo: PageInfo = {
+    endCursor: cursors.endCursor,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: cursors.startCursor,
+  };
+
+  return { nodes: items, pageInfo };
+};
+
+export const decodeCursor = (cursor: string): number => {
+  const decoded = Buffer.from(cursor, "base64").toString("utf-8");
+  const parts = decoded.split(":");
+
+  if (parts.length !== 2 || parts[0] !== CURSOR_PREFIX) {
+    throw new InvalidCursorError(INVALID_CURSOR_FORMAT_MESSAGE);
+  }
+
+  const id = parseInt(parts[1], 10);
+  if (Number.isNaN(id)) {
+    throw new InvalidCursorError(INVALID_CURSOR_ID_MESSAGE);
+  }
+
+  return id;
+};
+
+export const encodeCursor = (id: number): string => {
+  return Buffer.from(`${CURSOR_PREFIX}:${id}`).toString("base64");
+};
+
+const createCursors = <T extends { id: number }>(nodes: T[]) => {
+  if (nodes.length === 0) {
+    return { endCursor: undefined, startCursor: undefined };
+  }
+
+  return {
+    endCursor: encodeCursor(last(nodes).id),
+    startCursor: encodeCursor(nodes[0].id),
+  };
+};

--- a/src/backend/src/common/pagination/types.ts
+++ b/src/backend/src/common/pagination/types.ts
@@ -1,0 +1,32 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType({ isAbstract: true })
+export abstract class Connection<T> {
+  abstract edges: Edge<T>[];
+
+  @Field(() => PageInfo)
+  pageInfo: PageInfo;
+}
+
+@ObjectType({ isAbstract: true })
+export abstract class Edge<T> {
+  @Field(() => String)
+  cursor: string;
+
+  abstract node: T;
+}
+
+@ObjectType()
+export class PageInfo {
+  @Field(() => String, { nullable: true })
+  endCursor?: string;
+
+  @Field()
+  hasNextPage: boolean;
+
+  @Field()
+  hasPreviousPage: boolean;
+
+  @Field(() => String, { nullable: true })
+  startCursor?: string;
+}


### PR DESCRIPTION
GraphQL API의 일관된 페이지네이션과 mutation 응답을 위한 공통 인프라 추가

- Relay 스펙 기반 PageInfo, Edge, Connection 추상 타입 구현
- 커서 기반 페이지네이션 헬퍼 함수 제공 (encodeCursor, decodeCursor, createPageInfo)
- MutationResult 표준 응답 타입으로 성공/실패 및 필드별 에러 처리 통일
- 향후 Content 도메인부터 순차 적용 예정

fix #196