### PR TITLE
refactor(backend): Content 도메인 핵심 타입 정의 및 입력 검증 강화

### DIFF
--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -36,6 +36,8 @@ enum AuthProvider {
 
 type Content {
   contentCategory: ContentCategory!
+
+  """컨텐츠 카테고리 ID"""
   contentCategoryId: Int!
   contentRewards: [ContentReward!]!
   contentSeeMoreRewards: [ContentSeeMoreReward!]!
@@ -43,19 +45,31 @@ type Content {
   displayName: String!
   duration: Int!
   durationText: String!
+
+  """관문"""
   gate: Int
   id: Int!
+
+  """레벨"""
   level: Int!
+
+  """이름"""
   name: String!
+
+  """상태"""
+  status: ContentStatus!
   updatedAt: DateTime!
   wage(filter: ContentWageFilter): ContentWage!
-  wageFilter: ContentObjectWageFilter
 }
 
 type ContentCategory {
   createdAt: DateTime!
   id: Int!
+
+  """이미지 URL"""
   imageUrl: String!
+
+  """이름"""
   name: String!
   updatedAt: DateTime!
 }
@@ -144,12 +158,20 @@ type ContentDurationsEditResult {
 
 type ContentGroup {
   contentCategory: ContentCategory!
+
+  """컨텐츠 카테고리 ID"""
   contentCategoryId: Int!
+
+  """컨텐츠 ID 목록"""
   contentIds: [Int!]!
   contents: [Content!]!
   duration: Int!
   durationText: String!
+
+  """레벨"""
   level: Int!
+
+  """이름"""
   name: String!
 }
 
@@ -178,12 +200,6 @@ input ContentListFilter {
   includeIsSeeMore: Boolean
   keyword: String
   status: ContentStatus
-}
-
-type ContentObjectWageFilter {
-  includeIsBound: Boolean
-  includeIsSeeMore: Boolean
-  includeItemIds: [String!]
 }
 
 type ContentReward {

--- a/src/backend/src/content/dto/content.dto.ts
+++ b/src/backend/src/content/dto/content.dto.ts
@@ -1,55 +1,142 @@
-import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+import { Field, Float, InputType, Int, ObjectType } from "@nestjs/graphql";
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from "class-validator";
+import { ContentStatus } from "@prisma/client";
 
 @InputType()
-export class ContentCreateInput {
-  @Field({ description: "컨텐츠 카테고리 ID" })
+export class ContentFilterArgs {
+  @Field(() => Int, { description: "컨텐츠 카테고리 ID", nullable: true })
+  @IsInt()
+  @IsOptional()
+  categoryId?: number;
+
+  @Field(() => Int, { description: "관문", nullable: true })
+  @IsInt()
+  @IsOptional()
+  gate?: number;
+
+  @Field(() => Int, { description: "레벨", nullable: true })
+  @IsInt()
+  @IsOptional()
+  level?: number;
+
+  @Field(() => String, { description: "이름", nullable: true })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @Field(() => ContentStatus, { description: "상태", nullable: true })
+  @IsEnum(ContentStatus)
+  @IsOptional()
+  status?: ContentStatus;
+}
+
+@InputType("ContentCreateInput")
+export class CreateContentInput {
+  @Field(() => Int, { description: "컨텐츠 카테고리 ID" })
+  @IsInt()
+  @IsNotEmpty()
   categoryId: number;
 
-  @Field(() => [ContentCreateItemInput], { description: "컨텐츠 보상 목록" })
-  contentRewards: ContentCreateItemInput[];
+  @Field(() => [ContentRewardInput], { description: "컨텐츠 보상 목록" })
+  contentRewards: ContentRewardInput[];
 
-  @Field(() => [ContentCreateSeeMoreRewardInput], {
+  @Field(() => [ContentSeeMoreRewardInput], {
     description: "더보기 컨텐츠 보상 목록",
     nullable: true,
   })
-  contentSeeMoreRewards?: ContentCreateSeeMoreRewardInput[];
+  @IsOptional()
+  contentSeeMoreRewards?: ContentSeeMoreRewardInput[];
 
-  @Field({ description: "소요 시간 (초 단위)" })
+  @Field(() => Int, { description: "소요 시간 (초 단위)" })
+  @IsInt()
+  @Min(1)
   duration: number;
 
-  @Field({ description: "관문", nullable: true })
-  gate?: number | null;
+  @Field(() => Int, { description: "관문", nullable: true })
+  @IsInt()
+  @IsOptional()
+  gate?: number;
 
-  @Field({ description: "레벨" })
+  @Field(() => Int, { description: "레벨" })
+  @IsInt()
+  @Min(1)
   level: number;
 
-  @Field({ description: "이름" })
+  @Field(() => String, { description: "이름" })
+  @IsString()
+  @IsNotEmpty()
   name: string;
 }
 
 @InputType()
-export class ContentCreateItemInput {
+export class UpdateContentInput {
+  @Field(() => Int, { description: "관문", nullable: true })
+  @IsInt()
+  @IsOptional()
+  gate?: number;
+
+  @Field(() => Int, { description: "레벨", nullable: true })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  level?: number;
+
+  @Field(() => String, { description: "이름", nullable: true })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @Field(() => ContentStatus, { description: "상태", nullable: true })
+  @IsEnum(ContentStatus)
+  @IsOptional()
+  status?: ContentStatus;
+}
+
+@InputType("ContentCreateItemInput")
+export class ContentRewardInput {
   @Field(() => Float, { description: "평균 획득 수량" })
+  @IsNumber()
+  @Min(0)
   averageQuantity: number;
 
-  @Field({ description: "귀속 여부" })
+  @Field(() => Boolean, { description: "귀속 여부" })
+  @IsBoolean()
   isBound: boolean;
 
-  @Field({ description: "아이템 ID" })
+  @Field(() => Int, { description: "아이템 ID" })
+  @IsInt()
   itemId: number;
 }
 
-@ObjectType()
-export class ContentCreateResult {
+@InputType("ContentCreateSeeMoreRewardInput")
+export class ContentSeeMoreRewardInput {
+  @Field(() => Int, { description: "아이템 ID" })
+  @IsInt()
+  itemId: number;
+
+  @Field(() => Float, { description: "수량" })
+  @IsNumber()
+  @Min(0)
+  quantity: number;
+}
+
+@ObjectType("ContentCreateResult")
+export class ContentMutationResult {
   @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }
 
-@InputType()
-export class ContentCreateSeeMoreRewardInput {
-  @Field({ description: "아이템 ID" })
-  itemId: number;
-
-  @Field(() => Float, { description: "수량" })
-  quantity: number;
-}
+// Legacy alias for backward compatibility
+export { CreateContentInput as ContentCreateInput };
+export { ContentRewardInput as ContentCreateItemInput };
+export { ContentSeeMoreRewardInput as ContentCreateSeeMoreRewardInput };
+export { ContentMutationResult as ContentCreateResult };

--- a/src/backend/src/content/object/content-category.object.ts
+++ b/src/backend/src/content/object/content-category.object.ts
@@ -3,9 +3,9 @@ import { BaseObject } from "src/common/object/base.object";
 
 @ObjectType()
 export class ContentCategory extends BaseObject {
-  @Field()
+  @Field(() => String, { description: "이미지 URL" })
   imageUrl: string;
 
-  @Field()
+  @Field(() => String, { description: "이름" })
   name: string;
 }

--- a/src/backend/src/content/object/content-group.object.ts
+++ b/src/backend/src/content/object/content-group.object.ts
@@ -1,16 +1,16 @@
-import { Field, ObjectType } from "@nestjs/graphql";
+import { Field, Int, ObjectType } from "@nestjs/graphql";
 
 @ObjectType()
 export class ContentGroup {
-  @Field()
+  @Field(() => Int, { description: "컨텐츠 카테고리 ID" })
   contentCategoryId: number;
 
-  @Field(() => [Number])
+  @Field(() => [Int], { description: "컨텐츠 ID 목록" })
   contentIds: number[];
 
-  @Field()
+  @Field(() => Int, { description: "레벨" })
   level: number;
 
-  @Field()
+  @Field(() => String, { description: "이름" })
   name: string;
 }

--- a/src/backend/src/content/object/content.object.ts
+++ b/src/backend/src/content/object/content.object.ts
@@ -1,32 +1,21 @@
-import { Field, ObjectType } from "@nestjs/graphql";
+import { Field, Int, ObjectType } from "@nestjs/graphql";
+import { ContentStatus } from "@prisma/client";
 import { BaseObject } from "src/common/object/base.object";
 
 @ObjectType()
-export class ContentObjectWageFilter {
-  @Field(() => Boolean, { nullable: true })
-  includeIsBound?: boolean;
-
-  @Field(() => Boolean, { nullable: true })
-  includeIsSeeMore?: boolean;
-
-  @Field(() => [String], { nullable: true })
-  includeItemIds?: string[];
-}
-
-@ObjectType()
 export class Content extends BaseObject {
-  @Field()
+  @Field(() => Int, { description: "컨텐츠 카테고리 ID" })
   contentCategoryId: number;
 
-  @Field({ nullable: true })
+  @Field(() => Int, { description: "관문", nullable: true })
   gate?: number;
 
-  @Field()
+  @Field(() => Int, { description: "레벨" })
   level: number;
 
-  @Field()
+  @Field(() => String, { description: "이름" })
   name: string;
 
-  @Field(() => ContentObjectWageFilter, { nullable: true })
-  wageFilter?: ContentObjectWageFilter;
+  @Field(() => ContentStatus, { description: "상태" })
+  status: ContentStatus;
 }

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -49,6 +49,7 @@ export enum AuthProvider {
 export type Content = {
   __typename?: 'Content';
   contentCategory: ContentCategory;
+  /** 컨텐츠 카테고리 ID */
   contentCategoryId: Scalars['Int']['output'];
   contentRewards: Array<ContentReward>;
   contentSeeMoreRewards: Array<ContentSeeMoreReward>;
@@ -56,13 +57,17 @@ export type Content = {
   displayName: Scalars['String']['output'];
   duration: Scalars['Int']['output'];
   durationText: Scalars['String']['output'];
+  /** 관문 */
   gate?: Maybe<Scalars['Int']['output']>;
   id: Scalars['Int']['output'];
+  /** 레벨 */
   level: Scalars['Int']['output'];
+  /** 이름 */
   name: Scalars['String']['output'];
+  /** 상태 */
+  status: ContentStatus;
   updatedAt: Scalars['DateTime']['output'];
   wage: ContentWage;
-  wageFilter?: Maybe<ContentObjectWageFilter>;
 };
 
 
@@ -74,7 +79,9 @@ export type ContentCategory = {
   __typename?: 'ContentCategory';
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['Int']['output'];
+  /** 이미지 URL */
   imageUrl: Scalars['String']['output'];
+  /** 이름 */
   name: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -157,12 +164,16 @@ export type ContentDurationsEditResult = {
 export type ContentGroup = {
   __typename?: 'ContentGroup';
   contentCategory: ContentCategory;
+  /** 컨텐츠 카테고리 ID */
   contentCategoryId: Scalars['Int']['output'];
+  /** 컨텐츠 ID 목록 */
   contentIds: Array<Scalars['Int']['output']>;
   contents: Array<Content>;
   duration: Scalars['Int']['output'];
   durationText: Scalars['String']['output'];
+  /** 레벨 */
   level: Scalars['Int']['output'];
+  /** 이름 */
   name: Scalars['String']['output'];
 };
 
@@ -192,13 +203,6 @@ export type ContentListFilter = {
   includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
   keyword?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<ContentStatus>;
-};
-
-export type ContentObjectWageFilter = {
-  __typename?: 'ContentObjectWageFilter';
-  includeIsBound?: Maybe<Scalars['Boolean']['output']>;
-  includeIsSeeMore?: Maybe<Scalars['Boolean']['output']>;
-  includeItemIds?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 export type ContentReward = {


### PR DESCRIPTION
- Content, ContentCategory, ContentGroup ObjectType을 BaseObject 패턴으로 리팩토링
- ContentFilterArgs, CreateContentInput, UpdateContentInput에 class-validator 데코레이터 적용
- Content.status 필드 추가 (ContentStatus enum)
- 미사용 ContentObjectWageFilter 제거 및 ContentWageFilter로 통합
- GraphQL schema name 명시로 frontend 호환성 유지 (ContentCreateInput)

fix #199