### PR TITLE
refactor(graphql): InputType 네이밍 규칙 표준화 및 Boolean 필드명 개선

### DIFF
--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -13,7 +13,10 @@ type AuctionItem {
 }
 
 input AuctionItemListFilter {
+  """가격 통계 수집 활성화 여부"""
   isStatScraperEnabled: Boolean
+
+  """아이템 이름 검색 키워드"""
   nameKeyword: String
 }
 
@@ -23,8 +26,43 @@ enum AuthProvider {
   KAKAO
 }
 
+input CalculateCustomContentWageInput {
+  """아이템 목록"""
+  items: [CalculateCustomContentWageItemInput!]!
+
+  """분"""
+  minutes: Int!
+
+  """초"""
+  seconds: Int!
+}
+
+input CalculateCustomContentWageItemInput {
+  """아이템 ID"""
+  id: Int!
+
+  """획득 수량"""
+  quantity: Float!
+}
+
+type CalculateCustomContentWageResult {
+  """회당 골드 획득량"""
+  goldAmountPerClear: Int!
+
+  """시급 (골드)"""
+  goldAmountPerHour: Int!
+
+  """시급 (원화)"""
+  krwAmountPerHour: Int!
+
+  """성공 여부"""
+  ok: Boolean!
+}
+
 type Content {
   contentCategory: ContentCategory!
+
+  """컨텐츠 카테고리 ID"""
   contentCategoryId: Int!
   contentRewards: [ContentReward!]!
   contentSeeMoreRewards: [ContentSeeMoreReward!]!
@@ -32,12 +70,20 @@ type Content {
   displayName: String!
   duration: Int!
   durationText: String!
+
+  """관문 번호"""
   gate: Int
   id: Int!
+
+  """레벨"""
   level: Int!
+
+  """컨텐츠 이름"""
   name: String!
   updatedAt: DateTime!
   wage(filter: ContentWageFilter): ContentWage!
+
+  """시급 계산 필터"""
   wageFilter: ContentObjectWageFilter
 }
 
@@ -49,31 +95,6 @@ type ContentCategory {
   updatedAt: DateTime!
 }
 
-input ContentCreateInput {
-  categoryId: Int!
-  contentRewards: [ContentCreateItemsInput!]!
-  contentSeeMoreRewards: [ContentCreateSeeMoreRewardsInput!]
-  duration: Int!
-  gate: Int
-  level: Int!
-  name: String!
-}
-
-input ContentCreateItemsInput {
-  averageQuantity: Float!
-  isBound: Boolean!
-  itemId: Int!
-}
-
-type ContentCreateResult {
-  ok: Boolean!
-}
-
-input ContentCreateSeeMoreRewardsInput {
-  itemId: Int!
-  quantity: Float!
-}
-
 type ContentDuration {
   content: Content!
   contentId: Int!
@@ -81,30 +102,6 @@ type ContentDuration {
   id: Int!
   updatedAt: DateTime!
   value: Int!
-}
-
-input ContentDurationEditInput {
-  contentId: Int!
-  minutes: Int!
-  seconds: Int!
-}
-
-type ContentDurationEditResult {
-  ok: Boolean!
-}
-
-input ContentDurationsEditInput {
-  contentDurations: [ContentDurationsEditInputDuration!]!
-}
-
-input ContentDurationsEditInputDuration {
-  contentId: Int!
-  minutes: Int!
-  seconds: Int!
-}
-
-type ContentDurationsEditResult {
-  ok: Boolean!
 }
 
 type ContentGroup {
@@ -119,6 +116,7 @@ type ContentGroup {
 }
 
 input ContentGroupFilter {
+  """그룹화할 컨텐츠 ID 목록"""
   contentIds: [Int!]
 }
 
@@ -130,25 +128,48 @@ type ContentGroupWage {
 }
 
 input ContentGroupWageListFilter {
+  """필터링할 컨텐츠 카테고리 ID"""
   contentCategoryId: Int
-  includeIsBound: Boolean
-  includeIsSeeMore: Boolean
+
+  """귀속 아이템 포함 여부"""
+  includeBound: Boolean
+
+  """포함할 아이템 ID 목록"""
   includeItemIds: [Int!]
+
+  """추가 보상(더보기) 포함 여부"""
+  includeSeeMore: Boolean
+
+  """검색 키워드"""
   keyword: String
+
+  """컨텐츠 상태"""
   status: ContentStatus
 }
 
 input ContentListFilter {
+  """필터링할 컨텐츠 카테고리 ID"""
   contentCategoryId: Int
-  includeIsSeeMore: Boolean
+
+  """추가 보상(더보기) 포함 여부"""
+  includeSeeMore: Boolean
+
+  """검색 키워드"""
   keyword: String
+
+  """컨텐츠 상태"""
   status: ContentStatus
 }
 
 type ContentObjectWageFilter {
-  includeIsBound: Boolean
-  includeIsSeeMore: Boolean
+  """귀속 아이템 포함 여부"""
+  includeBound: Boolean
+
+  """포함할 아이템 ID 목록"""
   includeItemIds: [String!]
+
+  """추가 보상(더보기) 포함 여부"""
+  includeSeeMore: Boolean
 }
 
 type ContentReward {
@@ -161,35 +182,6 @@ type ContentReward {
   updatedAt: DateTime!
 }
 
-input ContentRewardEditInput {
-  averageQuantity: Float!
-  contentId: Int!
-  isSellable: Boolean!
-  itemId: Int!
-}
-
-input ContentRewardReportInput {
-  averageQuantity: Float!
-  id: Int!
-}
-
-input ContentRewardsEditInput {
-  contentRewards: [ContentRewardEditInput!]!
-  isReportable: Boolean!
-}
-
-type ContentRewardsEditResult {
-  ok: Boolean!
-}
-
-input ContentRewardsReportInput {
-  contentRewards: [ContentRewardReportInput!]!
-}
-
-type ContentRewardsReportResult {
-  ok: Boolean!
-}
-
 type ContentSeeMoreReward {
   contentId: Int!
   createdAt: DateTime!
@@ -198,20 +190,6 @@ type ContentSeeMoreReward {
   itemId: Int!
   quantity: Float!
   updatedAt: DateTime!
-}
-
-input ContentSeeMoreRewardEditInput {
-  contentId: Int!
-  itemId: Int!
-  quantity: Float!
-}
-
-input ContentSeeMoreRewardsEditInput {
-  contentSeeMoreRewards: [ContentSeeMoreRewardEditInput!]!
-}
-
-type ContentSeeMoreRewardsEditResult {
-  ok: Boolean!
 }
 
 enum ContentStatus {
@@ -228,40 +206,86 @@ type ContentWage {
 }
 
 input ContentWageFilter {
-  includeIsBound: Boolean
-  includeIsSeeMore: Boolean
+  """귀속 아이템 포함 여부"""
+  includeBound: Boolean
+
+  """포함할 아이템 ID 목록"""
   includeItemIds: [Int!]
+
+  """추가 보상(더보기) 포함 여부"""
+  includeSeeMore: Boolean
 }
 
 input ContentWageListFilter {
+  """필터링할 컨텐츠 카테고리 ID"""
   contentCategoryId: Int
-  includeIsBound: Boolean
-  includeIsSeeMore: Boolean
+
+  """귀속 아이템 포함 여부"""
+  includeBound: Boolean
+
+  """포함할 아이템 ID 목록"""
   includeItemIds: [Int!]
+
+  """추가 보상(더보기) 포함 여부"""
+  includeSeeMore: Boolean
+
+  """검색 키워드"""
   keyword: String
+
+  """컨텐츠 상태"""
   status: ContentStatus
 }
 
 input ContentsFilter {
+  """필터링할 컨텐츠 ID 목록"""
   ids: [Int!]
 }
 
-input CustomContentWageCalculateInput {
-  items: [CustomContentWageCalculateItemsInput!]!
-  minutes: Int!
-  seconds: Int!
+input CreateContentInput {
+  """컨텐츠 카테고리 ID"""
+  categoryId: Int!
+
+  """컨텐츠 보상 아이템 목록"""
+  contentRewards: [CreateContentItemInput!]!
+
+  """추가 보상(더보기) 아이템 목록"""
+  contentSeeMoreRewards: [CreateContentSeeMoreRewardInput!]
+
+  """소요 시간 (초)"""
+  duration: Int!
+
+  """관문 번호"""
+  gate: Int
+
+  """레벨"""
+  level: Int!
+
+  """컨텐츠 이름"""
+  name: String!
 }
 
-input CustomContentWageCalculateItemsInput {
-  id: Int!
-  quantity: Float!
+input CreateContentItemInput {
+  """평균 획득 수량"""
+  averageQuantity: Float!
+
+  """귀속 여부"""
+  isBound: Boolean!
+
+  """아이템 ID"""
+  itemId: Int!
 }
 
-type CustomContentWageCalculateResult {
-  goldAmountPerClear: Int!
-  goldAmountPerHour: Int!
-  krwAmountPerHour: Int!
+type CreateContentResult {
+  """성공 여부"""
   ok: Boolean!
+}
+
+input CreateContentSeeMoreRewardInput {
+  """아이템 ID"""
+  itemId: Int!
+
+  """획득 수량"""
+  quantity: Float!
 }
 
 """
@@ -269,20 +293,120 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+input EditContentDurationInput {
+  """컨텐츠 ID"""
+  contentId: Int!
+
+  """분"""
+  minutes: Int!
+
+  """초"""
+  seconds: Int!
+}
+
+type EditContentDurationResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
+input EditContentDurationsDurationInput {
+  """컨텐츠 ID"""
+  contentId: Int!
+
+  """분"""
+  minutes: Int!
+
+  """초"""
+  seconds: Int!
+}
+
+input EditContentDurationsInput {
+  """수정할 컨텐츠 소요 시간 목록"""
+  contentDurations: [EditContentDurationsDurationInput!]!
+}
+
+type EditContentDurationsResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
+input EditContentRewardInput {
+  """평균 획득 수량"""
+  averageQuantity: Float!
+
+  """컨텐츠 ID"""
+  contentId: Int!
+
+  """거래 가능 여부"""
+  isSellable: Boolean!
+
+  """아이템 ID"""
+  itemId: Int!
+}
+
+input EditContentRewardsInput {
+  """수정할 컨텐츠 보상 목록"""
+  contentRewards: [EditContentRewardInput!]!
+
+  """제보 가능 여부"""
+  isReportable: Boolean!
+}
+
+type EditContentRewardsResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
+input EditContentSeeMoreRewardInput {
+  """컨텐츠 ID"""
+  contentId: Int!
+
+  """아이템 ID"""
+  itemId: Int!
+
+  """획득 수량"""
+  quantity: Float!
+}
+
+input EditContentSeeMoreRewardsInput {
+  """수정할 추가 보상(더보기) 목록"""
+  contentSeeMoreRewards: [EditContentSeeMoreRewardInput!]!
+}
+
+type EditContentSeeMoreRewardsResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
+input EditGoldExchangeRateInput {
+  """100골드당 원화 금액"""
+  krwAmount: Int!
+}
+
+type EditGoldExchangeRateResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
+input EditUserItemPriceInput {
+  """아이템 ID"""
+  id: Int!
+
+  """사용자 지정 가격"""
+  price: Float!
+}
+
+type EditUserItemPriceResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
 type GoldExchangeRate {
   createdAt: DateTime!
   goldAmount: Float!
   id: Int!
   krwAmount: Float!
   updatedAt: DateTime!
-}
-
-input GoldExchangeRateEditInput {
-  krwAmount: Int!
-}
-
-type GoldExchangeRateEditResult {
-  ok: Boolean!
 }
 
 type Item {
@@ -303,7 +427,10 @@ enum ItemKind {
 }
 
 input ItemsFilter {
+  """제외할 아이템 이름"""
   excludeItemName: String
+
+  """아이템 종류"""
   kind: ItemKind
 }
 
@@ -322,22 +449,29 @@ type MarketItem {
 }
 
 input MarketItemListFilter {
+  """카테고리 이름"""
   categoryName: String
+
+  """등급"""
   grade: String
+
+  """가격 통계 수집 활성화 여부"""
   isStatScraperEnabled: Boolean
+
+  """검색 키워드"""
   keyword: String
 }
 
 type Mutation {
-  contentCreate(input: ContentCreateInput!): ContentCreateResult!
-  contentDurationEdit(input: ContentDurationEditInput!): ContentDurationEditResult!
-  contentDurationsEdit(input: ContentDurationsEditInput!): ContentDurationsEditResult!
-  contentRewardsEdit(input: ContentRewardsEditInput!): ContentRewardsEditResult!
-  contentRewardsReport(input: ContentRewardsReportInput!): ContentRewardsReportResult!
-  contentSeeMoreRewardsEdit(input: ContentSeeMoreRewardsEditInput!): ContentSeeMoreRewardsEditResult!
-  customContentWageCalculate(input: CustomContentWageCalculateInput!): CustomContentWageCalculateResult!
-  goldExchangeRateEdit(input: GoldExchangeRateEditInput!): GoldExchangeRateEditResult!
-  userItemPriceEdit(input: UserItemPriceEditInput!): UserItemPriceEditResult!
+  contentCreate(input: CreateContentInput!): CreateContentResult!
+  contentDurationEdit(input: EditContentDurationInput!): EditContentDurationResult!
+  contentDurationsEdit(input: EditContentDurationsInput!): EditContentDurationsResult!
+  contentRewardsEdit(input: EditContentRewardsInput!): EditContentRewardsResult!
+  contentRewardsReport(input: ReportContentRewardsInput!): ReportContentRewardsResult!
+  contentSeeMoreRewardsEdit(input: EditContentSeeMoreRewardsInput!): EditContentSeeMoreRewardsResult!
+  customContentWageCalculate(input: CalculateCustomContentWageInput!): CalculateCustomContentWageResult!
+  goldExchangeRateEdit(input: EditGoldExchangeRateInput!): EditGoldExchangeRateResult!
+  userItemPriceEdit(input: EditUserItemPriceInput!): EditUserItemPriceResult!
 }
 
 input OrderByArg {
@@ -364,6 +498,24 @@ type Query {
   userList: [User!]!
 }
 
+input ReportContentRewardInput {
+  """평균 획득 수량"""
+  averageQuantity: Float!
+
+  """컨텐츠 보상 ID"""
+  id: Int!
+}
+
+input ReportContentRewardsInput {
+  """제보할 컨텐츠 보상 목록"""
+  contentRewards: [ReportContentRewardInput!]!
+}
+
+type ReportContentRewardsResult {
+  """성공 여부"""
+  ok: Boolean!
+}
+
 type User {
   createdAt: DateTime!
   displayName: String!
@@ -383,15 +535,6 @@ type UserItem {
   price: Float!
   updatedAt: DateTime!
   userId: Int!
-}
-
-input UserItemPriceEditInput {
-  id: Int!
-  price: Float!
-}
-
-type UserItemPriceEditResult {
-  ok: Boolean!
 }
 
 enum UserRole {

--- a/src/backend/src/content/content/content.dto.ts
+++ b/src/backend/src/content/content/content.dto.ts
@@ -3,72 +3,92 @@ import { ContentStatus } from "@prisma/client";
 
 @InputType()
 export class ContentListFilter {
-  @Field({ nullable: true })
+  @Field({
+    description: "필터링할 컨텐츠 카테고리 ID",
+    nullable: true,
+  })
   contentCategoryId?: number;
 
-  @Field(() => Boolean, { nullable: true })
-  includeIsSeeMore?: boolean;
+  @Field(() => Boolean, {
+    description: "추가 보상(더보기) 포함 여부",
+    nullable: true,
+  })
+  includeSeeMore?: boolean;
 
-  @Field(() => String, { nullable: true })
+  @Field(() => String, {
+    description: "검색 키워드",
+    nullable: true,
+  })
   keyword?: string;
 
-  @Field(() => ContentStatus, { nullable: true })
+  @Field(() => ContentStatus, {
+    description: "컨텐츠 상태",
+    nullable: true,
+  })
   status?: ContentStatus;
 }
 
 @InputType()
 export class ContentsFilter {
-  @Field(() => [Number], { nullable: true })
+  @Field(() => [Number], {
+    description: "필터링할 컨텐츠 ID 목록",
+    nullable: true,
+  })
   ids?: number[];
 }
 
 @InputType()
-export class ContentCreateInput {
-  @Field()
+export class CreateContentInput {
+  @Field({ description: "컨텐츠 카테고리 ID" })
   categoryId: number;
 
-  @Field(() => [ContentCreateItemsInput])
-  contentRewards: ContentCreateItemsInput[];
+  @Field(() => [CreateContentItemInput], {
+    description: "컨텐츠 보상 아이템 목록",
+  })
+  contentRewards: CreateContentItemInput[];
 
-  @Field(() => [ContentCreateSeeMoreRewardsInput], { nullable: true })
-  contentSeeMoreRewards?: ContentCreateSeeMoreRewardsInput[];
+  @Field(() => [CreateContentSeeMoreRewardInput], {
+    description: "추가 보상(더보기) 아이템 목록",
+    nullable: true,
+  })
+  contentSeeMoreRewards?: CreateContentSeeMoreRewardInput[];
 
-  @Field()
+  @Field({ description: "소요 시간 (초)" })
   duration: number;
 
-  @Field({ nullable: true })
+  @Field({ description: "관문 번호", nullable: true })
   gate?: number | null;
 
-  @Field()
+  @Field({ description: "레벨" })
   level: number;
 
-  @Field()
+  @Field({ description: "컨텐츠 이름" })
   name: string;
 }
 
 @InputType()
-export class ContentCreateItemsInput {
-  @Field(() => Float)
+export class CreateContentItemInput {
+  @Field(() => Float, { description: "평균 획득 수량" })
   averageQuantity: number;
 
-  @Field()
+  @Field({ description: "귀속 여부" })
   isBound: boolean;
 
-  @Field()
+  @Field({ description: "아이템 ID" })
   itemId: number;
 }
 
 @InputType()
-export class ContentCreateSeeMoreRewardsInput {
-  @Field()
+export class CreateContentSeeMoreRewardInput {
+  @Field({ description: "아이템 ID" })
   itemId: number;
 
-  @Field(() => Float)
+  @Field(() => Float, { description: "획득 수량" })
   quantity: number;
 }
 
 @ObjectType()
-export class ContentCreateResult {
-  @Field(() => Boolean)
+export class CreateContentResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/content/content.object.ts
+++ b/src/backend/src/content/content/content.object.ts
@@ -3,30 +3,42 @@ import { BaseObject } from "src/common/object/base.object";
 
 @ObjectType()
 export class ContentObjectWageFilter {
-  @Field(() => Boolean, { nullable: true })
-  includeIsBound?: boolean;
+  @Field(() => Boolean, {
+    description: "귀속 아이템 포함 여부",
+    nullable: true,
+  })
+  includeBound?: boolean;
 
-  @Field(() => Boolean, { nullable: true })
-  includeIsSeeMore?: boolean;
-
-  @Field(() => [String], { nullable: true })
+  @Field(() => [String], {
+    description: "포함할 아이템 ID 목록",
+    nullable: true,
+  })
   includeItemIds?: string[];
+
+  @Field(() => Boolean, {
+    description: "추가 보상(더보기) 포함 여부",
+    nullable: true,
+  })
+  includeSeeMore?: boolean;
 }
 
 @ObjectType()
 export class Content extends BaseObject {
-  @Field()
+  @Field({ description: "컨텐츠 카테고리 ID" })
   contentCategoryId: number;
 
-  @Field({ nullable: true })
+  @Field({ description: "관문 번호", nullable: true })
   gate?: number;
 
-  @Field()
+  @Field({ description: "레벨" })
   level: number;
 
-  @Field()
+  @Field({ description: "컨텐츠 이름" })
   name: string;
 
-  @Field(() => ContentObjectWageFilter, { nullable: true })
+  @Field(() => ContentObjectWageFilter, {
+    description: "시급 계산 필터",
+    nullable: true,
+  })
   wageFilter?: ContentObjectWageFilter;
 }

--- a/src/backend/src/content/content/content.resolver.ts
+++ b/src/backend/src/content/content/content.resolver.ts
@@ -10,10 +10,10 @@ import { ContentWageService } from "../wage/wage.service";
 import { ContentWageFilter } from "../wage/wage.dto";
 import { ContentWage } from "../wage/wage.object";
 import {
-  ContentCreateInput,
-  ContentCreateResult,
   ContentListFilter,
   ContentsFilter,
+  CreateContentInput,
+  CreateContentResult,
 } from "./content.dto";
 import { ContentService } from "./content.service";
 import { Content } from "./content.object";
@@ -43,8 +43,8 @@ export class ContentResolver {
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentCreateResult)
-  async contentCreate(@Args("input") input: ContentCreateInput) {
+  @Mutation(() => CreateContentResult)
+  async contentCreate(@Args("input") input: CreateContentInput) {
     return await this.contentService.createContent(input);
   }
 

--- a/src/backend/src/content/content/content.service.ts
+++ b/src/backend/src/content/content/content.service.ts
@@ -3,10 +3,10 @@ import { Content, Prisma } from "@prisma/client";
 import { NotFoundException } from "src/common/exception/not-found.exception";
 import { PrismaService } from "src/prisma";
 import {
-  ContentCreateInput,
-  ContentCreateResult,
   ContentListFilter,
   ContentsFilter,
+  CreateContentInput,
+  CreateContentResult,
 } from "./content.dto";
 
 const RAID_CATEGORIES = ["에픽 레이드", "카제로스 레이드", "강습 레이드", "군단장 레이드"];
@@ -60,7 +60,7 @@ export class ContentService {
     return where;
   }
 
-  async createContent(input: ContentCreateInput): Promise<ContentCreateResult> {
+  async createContent(input: CreateContentInput): Promise<CreateContentResult> {
     const { categoryId, contentRewards, contentSeeMoreRewards, duration, gate, level, name } =
       input;
 

--- a/src/backend/src/content/duration/duration.dto.ts
+++ b/src/backend/src/content/duration/duration.dto.ts
@@ -1,43 +1,45 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
 
 @InputType()
-export class ContentDurationEditInput {
-  @Field()
+export class EditContentDurationInput {
+  @Field({ description: "컨텐츠 ID" })
   contentId: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "분" })
   minutes: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "초" })
   seconds: number;
 }
 
 @ObjectType()
-export class ContentDurationEditResult {
-  @Field(() => Boolean)
+export class EditContentDurationResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }
 
 @InputType()
-export class ContentDurationsEditInputDuration {
-  @Field()
+export class EditContentDurationsDurationInput {
+  @Field({ description: "컨텐츠 ID" })
   contentId: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "분" })
   minutes: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "초" })
   seconds: number;
 }
 
 @InputType()
-export class ContentDurationsEditInput {
-  @Field(() => [ContentDurationsEditInputDuration])
-  contentDurations: ContentDurationsEditInputDuration[];
+export class EditContentDurationsInput {
+  @Field(() => [EditContentDurationsDurationInput], {
+    description: "수정할 컨텐츠 소요 시간 목록",
+  })
+  contentDurations: EditContentDurationsDurationInput[];
 }
 
 @ObjectType()
-export class ContentDurationsEditResult {
-  @Field(() => Boolean)
+export class EditContentDurationsResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/duration/duration.resolver.ts
+++ b/src/backend/src/content/duration/duration.resolver.ts
@@ -8,10 +8,10 @@ import { PrismaService } from "src/prisma";
 import { Content } from "../content/content.object";
 import { ContentDurationService } from "./duration.service";
 import {
-  ContentDurationEditInput,
-  ContentDurationEditResult,
-  ContentDurationsEditInput,
-  ContentDurationsEditResult,
+  EditContentDurationInput,
+  EditContentDurationResult,
+  EditContentDurationsInput,
+  EditContentDurationsResult,
 } from "./duration.dto";
 import { ContentDuration } from "./duration.object";
 
@@ -32,9 +32,9 @@ export class DurationResolver {
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentDurationEditResult)
+  @Mutation(() => EditContentDurationResult)
   async contentDurationEdit(
-    @Args("input") input: ContentDurationEditInput,
+    @Args("input") input: EditContentDurationInput,
     @CurrentUser() user: User
   ) {
     const { contentId, minutes, seconds } = input;
@@ -67,9 +67,9 @@ export class DurationResolver {
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentDurationsEditResult)
+  @Mutation(() => EditContentDurationsResult)
   async contentDurationsEdit(
-    @Args("input") input: ContentDurationsEditInput,
+    @Args("input") input: EditContentDurationsInput,
     @CurrentUser() user: User
   ) {
     const { contentDurations } = input;

--- a/src/backend/src/content/group/group.dto.ts
+++ b/src/backend/src/content/group/group.dto.ts
@@ -4,18 +4,24 @@ import { ContentWageFilter } from "../wage/wage.dto";
 
 @InputType()
 export class ContentGroupFilter {
-  @Field(() => [Number], { nullable: true })
+  @Field(() => [Number], {
+    description: "그룹화할 컨텐츠 ID 목록",
+    nullable: true,
+  })
   contentIds?: number[];
 }
 
 @InputType()
 export class ContentGroupWageListFilter extends ContentWageFilter {
-  @Field({ nullable: true })
+  @Field({
+    description: "필터링할 컨텐츠 카테고리 ID",
+    nullable: true,
+  })
   contentCategoryId?: number;
 
-  @Field(() => String, { nullable: true })
+  @Field(() => String, { description: "검색 키워드", nullable: true })
   keyword?: string;
 
-  @Field(() => ContentStatus, { nullable: true })
+  @Field(() => ContentStatus, { description: "컨텐츠 상태", nullable: true })
   status?: ContentStatus;
 }

--- a/src/backend/src/content/group/group.service.spec.ts
+++ b/src/backend/src/content/group/group.service.spec.ts
@@ -375,15 +375,15 @@ describe("GroupService", () => {
       });
 
       await service.findContentGroupWageList({
-        includeIsBound: false,
-        includeIsSeeMore: true,
+        includeBound: false,
         includeItemIds: [1, 2, 3],
+        includeSeeMore: true,
       });
 
       expect(contentWageService.getContentGroupWage).toHaveBeenCalledWith([1], {
-        includeIsBound: false,
-        includeIsSeeMore: true,
+        includeBound: false,
         includeItemIds: [1, 2, 3],
+        includeSeeMore: true,
       });
     });
   });

--- a/src/backend/src/content/group/group.service.ts
+++ b/src/backend/src/content/group/group.service.ts
@@ -113,9 +113,9 @@ export class GroupService {
       const representative = groupContents[0];
 
       const wage = await this.contentWageService.getContentGroupWage(contentIds, {
-        includeIsBound: filter?.includeIsBound,
-        includeIsSeeMore: filter?.includeIsSeeMore,
+        includeBound: filter?.includeBound,
         includeItemIds: filter?.includeItemIds,
+        includeSeeMore: filter?.includeSeeMore,
       });
 
       return {

--- a/src/backend/src/content/item/item.dto.ts
+++ b/src/backend/src/content/item/item.dto.ts
@@ -3,24 +3,24 @@ import { ItemKind } from "@prisma/client";
 
 @InputType()
 export class ItemsFilter {
-  @Field({ nullable: true })
+  @Field({ description: "제외할 아이템 이름", nullable: true })
   excludeItemName?: string;
 
-  @Field(() => ItemKind, { nullable: true })
+  @Field(() => ItemKind, { description: "아이템 종류", nullable: true })
   kind?: ItemKind;
 }
 
 @InputType()
-export class UserItemPriceEditInput {
-  @Field()
+export class EditUserItemPriceInput {
+  @Field({ description: "아이템 ID" })
   id: number;
 
-  @Field(() => Float)
+  @Field(() => Float, { description: "사용자 지정 가격" })
   price: number;
 }
 
 @ObjectType()
-export class UserItemPriceEditResult {
-  @Field(() => Boolean)
+export class EditUserItemPriceResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/item/item.resolver.ts
+++ b/src/backend/src/content/item/item.resolver.ts
@@ -5,7 +5,7 @@ import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
 import { PrismaService } from "src/prisma";
 import { UserContentService } from "src/user/service/user-content.service";
-import { ItemsFilter, UserItemPriceEditInput, UserItemPriceEditResult } from "./item.dto";
+import { EditUserItemPriceInput, EditUserItemPriceResult, ItemsFilter } from "./item.dto";
 import { ItemService } from "./item.service";
 import { Item, UserItem } from "./item.object";
 
@@ -28,8 +28,8 @@ export class ItemResolver {
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => UserItemPriceEditResult)
-  async userItemPriceEdit(@Args("input") input: UserItemPriceEditInput) {
+  @Mutation(() => EditUserItemPriceResult)
+  async userItemPriceEdit(@Args("input") input: EditUserItemPriceInput) {
     return await this.itemService.editUserItemPrice(input);
   }
 

--- a/src/backend/src/content/item/item.service.ts
+++ b/src/backend/src/content/item/item.service.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 import { PrismaService } from "src/prisma";
 import { UserContentService } from "src/user/service/user-content.service";
 import { ItemSortOrder } from "../shared/constants";
-import { ItemsFilter, UserItemPriceEditInput, UserItemPriceEditResult } from "./item.dto";
+import { ItemsFilter, EditUserItemPriceInput, EditUserItemPriceResult } from "./item.dto";
 import { Item } from "./item.object";
 
 @Injectable()
@@ -29,7 +29,7 @@ export class ItemService {
     return where;
   }
 
-  async editUserItemPrice(input: UserItemPriceEditInput): Promise<UserItemPriceEditResult> {
+  async editUserItemPrice(input: EditUserItemPriceInput): Promise<EditUserItemPriceResult> {
     const { id, price } = input;
 
     await this.userContentService.validateUserItem(id);

--- a/src/backend/src/content/reward/reward.dto.ts
+++ b/src/backend/src/content/reward/reward.dto.ts
@@ -1,52 +1,56 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
 
 @InputType()
-export class ContentRewardEditInput {
-  @Field(() => Float)
+export class EditContentRewardInput {
+  @Field(() => Float, { description: "평균 획득 수량" })
   averageQuantity: number;
 
-  @Field()
+  @Field({ description: "컨텐츠 ID" })
   contentId: number;
 
-  @Field(() => Boolean)
+  @Field(() => Boolean, { description: "거래 가능 여부" })
   isSellable: boolean;
 
-  @Field()
+  @Field({ description: "아이템 ID" })
   itemId: number;
 }
 
 @InputType()
-export class ContentRewardsEditInput {
-  @Field(() => [ContentRewardEditInput])
-  contentRewards: ContentRewardEditInput[];
+export class EditContentRewardsInput {
+  @Field(() => [EditContentRewardInput], {
+    description: "수정할 컨텐츠 보상 목록",
+  })
+  contentRewards: EditContentRewardInput[];
 
-  @Field()
+  @Field({ description: "제보 가능 여부" })
   isReportable: boolean;
 }
 
 @ObjectType()
-export class ContentRewardsEditResult {
-  @Field(() => Boolean)
+export class EditContentRewardsResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }
 
 @InputType()
-export class ContentRewardReportInput {
-  @Field(() => Float)
+export class ReportContentRewardInput {
+  @Field(() => Float, { description: "평균 획득 수량" })
   averageQuantity: number;
 
-  @Field()
+  @Field({ description: "컨텐츠 보상 ID" })
   id: number;
 }
 
 @InputType()
-export class ContentRewardsReportInput {
-  @Field(() => [ContentRewardReportInput])
-  contentRewards: ContentRewardReportInput[];
+export class ReportContentRewardsInput {
+  @Field(() => [ReportContentRewardInput], {
+    description: "제보할 컨텐츠 보상 목록",
+  })
+  contentRewards: ReportContentRewardInput[];
 }
 
 @ObjectType()
-export class ContentRewardsReportResult {
-  @Field(() => Boolean)
+export class ReportContentRewardsResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/reward/reward.resolver.ts
+++ b/src/backend/src/content/reward/reward.resolver.ts
@@ -7,10 +7,10 @@ import { DataLoaderService } from "src/dataloader/data-loader.service";
 import { UserContentService } from "src/user/service/user-content.service";
 import { Item } from "../item/item.object";
 import {
-  ContentRewardsEditInput,
-  ContentRewardsEditResult,
-  ContentRewardsReportInput,
-  ContentRewardsReportResult,
+  EditContentRewardsInput,
+  EditContentRewardsResult,
+  ReportContentRewardsInput,
+  ReportContentRewardsResult,
 } from "./reward.dto";
 import { RewardService } from "./reward.service";
 import { ContentReward } from "./reward.object";
@@ -24,18 +24,18 @@ export class RewardResolver {
   ) {}
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentRewardsEditResult)
+  @Mutation(() => EditContentRewardsResult)
   async contentRewardsEdit(
-    @Args("input") input: ContentRewardsEditInput,
+    @Args("input") input: EditContentRewardsInput,
     @CurrentUser() user: User
   ) {
     return await this.rewardService.editContentRewards(input, user.id, user.role);
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentRewardsReportResult)
+  @Mutation(() => ReportContentRewardsResult)
   async contentRewardsReport(
-    @Args("input") input: ContentRewardsReportInput,
+    @Args("input") input: ReportContentRewardsInput,
     @CurrentUser() user: User
   ) {
     return await this.rewardService.reportContentRewards(input, user.id);

--- a/src/backend/src/content/reward/reward.service.ts
+++ b/src/backend/src/content/reward/reward.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from "@nestjs/common";
 import { Prisma, UserRole } from "@prisma/client";
 import { PrismaService } from "src/prisma";
 import {
-  ContentRewardsEditInput,
-  ContentRewardsEditResult,
-  ContentRewardsReportInput,
-  ContentRewardsReportResult,
+  EditContentRewardsInput,
+  EditContentRewardsResult,
+  ReportContentRewardsInput,
+  ReportContentRewardsResult,
 } from "./reward.dto";
 
 type TransactionClient = Prisma.TransactionClient;
@@ -15,10 +15,10 @@ export class RewardService {
   constructor(private prisma: PrismaService) {}
 
   async editContentRewards(
-    input: ContentRewardsEditInput,
+    input: EditContentRewardsInput,
     userId: number,
     userRole: UserRole
-  ): Promise<ContentRewardsEditResult> {
+  ): Promise<EditContentRewardsResult> {
     return await this.prisma.$transaction(async (tx) => {
       if (userRole === UserRole.OWNER) {
         await this.updateOwnerRewards(tx, input);
@@ -35,9 +35,9 @@ export class RewardService {
   }
 
   async reportContentRewards(
-    input: ContentRewardsReportInput,
+    input: ReportContentRewardsInput,
     userId: number
-  ): Promise<ContentRewardsReportResult> {
+  ): Promise<ReportContentRewardsResult> {
     return await this.prisma.$transaction(async (tx) => {
       await Promise.all(
         input.contentRewards.map(async ({ averageQuantity, id }) => {
@@ -57,7 +57,7 @@ export class RewardService {
 
   private async createRewardReports(
     tx: TransactionClient,
-    input: ContentRewardsEditInput,
+    input: EditContentRewardsInput,
     userId: number
   ): Promise<void> {
     await Promise.all(
@@ -79,7 +79,7 @@ export class RewardService {
 
   private async updateOwnerRewards(
     tx: TransactionClient,
-    input: ContentRewardsEditInput
+    input: EditContentRewardsInput
   ): Promise<void> {
     await Promise.all(
       input.contentRewards.map(async ({ averageQuantity, contentId, isSellable, itemId }) => {
@@ -101,7 +101,7 @@ export class RewardService {
 
   private async upsertUserRewards(
     tx: TransactionClient,
-    input: ContentRewardsEditInput,
+    input: EditContentRewardsInput,
     userId: number
   ): Promise<void> {
     await Promise.all(

--- a/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
@@ -1,25 +1,27 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
 
 @InputType()
-export class ContentSeeMoreRewardEditInput {
-  @Field()
+export class EditContentSeeMoreRewardInput {
+  @Field({ description: "컨텐츠 ID" })
   contentId: number;
 
-  @Field()
+  @Field({ description: "아이템 ID" })
   itemId: number;
 
-  @Field(() => Float)
+  @Field(() => Float, { description: "획득 수량" })
   quantity: number;
 }
 
 @InputType()
-export class ContentSeeMoreRewardsEditInput {
-  @Field(() => [ContentSeeMoreRewardEditInput])
-  contentSeeMoreRewards: ContentSeeMoreRewardEditInput[];
+export class EditContentSeeMoreRewardsInput {
+  @Field(() => [EditContentSeeMoreRewardInput], {
+    description: "수정할 추가 보상(더보기) 목록",
+  })
+  contentSeeMoreRewards: EditContentSeeMoreRewardInput[];
 }
 
 @ObjectType()
-export class ContentSeeMoreRewardsEditResult {
-  @Field(() => Boolean)
+export class EditContentSeeMoreRewardsResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/see-more-reward/see-more-reward.resolver.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.resolver.ts
@@ -7,8 +7,8 @@ import { DataLoaderService } from "src/dataloader/data-loader.service";
 import { UserContentService } from "src/user/service/user-content.service";
 import { Item } from "../item/item.object";
 import {
-  ContentSeeMoreRewardsEditInput,
-  ContentSeeMoreRewardsEditResult,
+  EditContentSeeMoreRewardsInput,
+  EditContentSeeMoreRewardsResult,
 } from "./see-more-reward.dto";
 import { SeeMoreRewardService } from "./see-more-reward.service";
 import { ContentSeeMoreReward } from "./see-more-reward.object";
@@ -22,9 +22,9 @@ export class SeeMoreRewardResolver {
   ) {}
 
   @UseGuards(AuthGuard)
-  @Mutation(() => ContentSeeMoreRewardsEditResult)
+  @Mutation(() => EditContentSeeMoreRewardsResult)
   async contentSeeMoreRewardsEdit(
-    @Args("input") input: ContentSeeMoreRewardsEditInput,
+    @Args("input") input: EditContentSeeMoreRewardsInput,
     @CurrentUser() user: User
   ) {
     return await this.seeMoreRewardService.editContentSeeMoreRewards(input, user.id, user.role);

--- a/src/backend/src/content/see-more-reward/see-more-reward.service.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from "@nestjs/common";
 import { Prisma, UserRole } from "@prisma/client";
 import { PrismaService } from "src/prisma";
 import {
-  ContentSeeMoreRewardsEditInput,
-  ContentSeeMoreRewardsEditResult,
+  EditContentSeeMoreRewardsInput,
+  EditContentSeeMoreRewardsResult,
 } from "./see-more-reward.dto";
 
 type TransactionClient = Prisma.TransactionClient;
@@ -13,10 +13,10 @@ export class SeeMoreRewardService {
   constructor(private prisma: PrismaService) {}
 
   async editContentSeeMoreRewards(
-    input: ContentSeeMoreRewardsEditInput,
+    input: EditContentSeeMoreRewardsInput,
     userId: number,
     userRole: UserRole
-  ): Promise<ContentSeeMoreRewardsEditResult> {
+  ): Promise<EditContentSeeMoreRewardsResult> {
     return await this.prisma.$transaction(async (tx) => {
       if (userRole === UserRole.OWNER) {
         await this.updateOwnerSeeMoreRewards(tx, input);
@@ -30,7 +30,7 @@ export class SeeMoreRewardService {
 
   private async updateOwnerSeeMoreRewards(
     tx: TransactionClient,
-    input: ContentSeeMoreRewardsEditInput
+    input: EditContentSeeMoreRewardsInput
   ): Promise<void> {
     await Promise.all(
       input.contentSeeMoreRewards.map(async ({ contentId, itemId, quantity }) => {
@@ -48,7 +48,7 @@ export class SeeMoreRewardService {
 
   private async upsertUserSeeMoreRewards(
     tx: TransactionClient,
-    input: ContentSeeMoreRewardsEditInput,
+    input: EditContentSeeMoreRewardsInput,
     userId: number
   ): Promise<void> {
     await Promise.all(

--- a/src/backend/src/content/wage/wage.dto.ts
+++ b/src/backend/src/content/wage/wage.dto.ts
@@ -3,60 +3,74 @@ import { ContentStatus } from "@prisma/client";
 
 @InputType()
 export class ContentWageFilter {
-  @Field(() => Boolean, { nullable: true })
-  includeIsBound?: boolean;
+  @Field(() => Boolean, {
+    description: "귀속 아이템 포함 여부",
+    nullable: true,
+  })
+  includeBound?: boolean;
 
-  @Field(() => Boolean, { nullable: true })
-  includeIsSeeMore?: boolean;
-
-  @Field(() => [Number], { nullable: true })
+  @Field(() => [Number], {
+    description: "포함할 아이템 ID 목록",
+    nullable: true,
+  })
   includeItemIds?: number[];
+
+  @Field(() => Boolean, {
+    description: "추가 보상(더보기) 포함 여부",
+    nullable: true,
+  })
+  includeSeeMore?: boolean;
 }
 
 @InputType()
 export class ContentWageListFilter extends ContentWageFilter {
-  @Field({ nullable: true })
+  @Field({
+    description: "필터링할 컨텐츠 카테고리 ID",
+    nullable: true,
+  })
   contentCategoryId?: number;
 
-  @Field(() => String, { nullable: true })
+  @Field(() => String, { description: "검색 키워드", nullable: true })
   keyword?: string;
 
-  @Field(() => ContentStatus, { nullable: true })
+  @Field(() => ContentStatus, { description: "컨텐츠 상태", nullable: true })
   status?: ContentStatus;
 }
 
 @InputType()
-export class CustomContentWageCalculateInput {
-  @Field(() => [CustomContentWageCalculateItemsInput])
-  items: CustomContentWageCalculateItemsInput[];
+export class CalculateCustomContentWageInput {
+  @Field(() => [CalculateCustomContentWageItemInput], {
+    description: "아이템 목록",
+  })
+  items: CalculateCustomContentWageItemInput[];
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "분" })
   minutes: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { description: "초" })
   seconds: number;
 }
 
 @InputType()
-export class CustomContentWageCalculateItemsInput {
-  @Field()
+export class CalculateCustomContentWageItemInput {
+  @Field({ description: "아이템 ID" })
   id: number;
 
-  @Field(() => Float)
+  @Field(() => Float, { description: "획득 수량" })
   quantity: number;
 }
 
 @ObjectType()
-export class CustomContentWageCalculateResult {
-  @Field()
+export class CalculateCustomContentWageResult {
+  @Field({ description: "회당 골드 획득량" })
   goldAmountPerClear: number;
 
-  @Field()
+  @Field({ description: "시급 (골드)" })
   goldAmountPerHour: number;
 
-  @Field()
+  @Field({ description: "시급 (원화)" })
   krwAmountPerHour: number;
 
-  @Field(() => Boolean)
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/content/wage/wage.resolver.e2e-spec.ts
+++ b/src/backend/src/content/wage/wage.resolver.e2e-spec.ts
@@ -319,7 +319,7 @@ describe("ContentWageListQuery (e2e)", () => {
     expect(response.body.data.contentWageList[0].goldAmountPerClear).toBe(500); // item1만 계산 (100 * 5)
   });
 
-  it("includeIsSeeMore 필터", async () => {
+  it("includeSeeMore 필터", async () => {
     // 콘텐츠 생성
     const content = await contentFactory.create();
 
@@ -358,14 +358,14 @@ describe("ContentWageListQuery (e2e)", () => {
       },
     });
 
-    // includeIsSeeMore = true로 쿼리
+    // includeSeeMore = true로 쿼리
     const responseWithSeeMore = await request(app.getHttpServer())
       .post("/graphql")
       .set("Content-Type", "application/json")
       .send({
         query: `
           query {
-            contentWageList(filter: { includeIsSeeMore: true }) {
+            contentWageList(filter: { includeSeeMore: true }) {
               contentId
               goldAmountPerClear
             }
@@ -373,14 +373,14 @@ describe("ContentWageListQuery (e2e)", () => {
         `,
       });
 
-    // includeIsSeeMore = false로 쿼리
+    // includeSeeMore = false로 쿼리
     const responseWithoutSeeMore = await request(app.getHttpServer())
       .post("/graphql")
       .set("Content-Type", "application/json")
       .send({
         query: `
           query {
-            contentWageList(filter: { includeIsSeeMore: false }) {
+            contentWageList(filter: { includeSeeMore: false }) {
               contentId
               goldAmountPerClear
             }
@@ -401,7 +401,7 @@ describe("ContentWageListQuery (e2e)", () => {
     expect(goldWithoutSeeMore).toBe(500); // 일반 500만
   });
 
-  it("includeIsBound 필터", async () => {
+  it("includeBound 필터", async () => {
     // 콘텐츠 생성
     const content = await contentFactory.create();
 
@@ -448,14 +448,14 @@ describe("ContentWageListQuery (e2e)", () => {
       },
     });
 
-    // includeIsBound = false로 쿼리 (거래 가능 아이템만)
+    // includeBound = false로 쿼리 (거래 가능 아이템만)
     const response = await request(app.getHttpServer())
       .post("/graphql")
       .set("Content-Type", "application/json")
       .send({
         query: `
           query {
-            contentWageList(filter: { includeIsBound: false }) {
+            contentWageList(filter: { includeBound: false }) {
               contentId
               goldAmountPerClear
             }
@@ -649,7 +649,7 @@ describe("ContentWageListQuery (e2e)", () => {
               filter: { 
                 contentCategoryId: ${category1.id},
                 keyword: "특수",
-                includeIsBound: false,
+                includeBound: false,
                 includeItemIds: [${item1.id}]
               }
             ) {

--- a/src/backend/src/content/wage/wage.resolver.ts
+++ b/src/backend/src/content/wage/wage.resolver.ts
@@ -7,9 +7,9 @@ import { Content } from "../content/content.object";
 import { ContentDurationService } from "../duration/duration.service";
 import { ContentWageService } from "./wage.service";
 import {
+  CalculateCustomContentWageInput,
+  CalculateCustomContentWageResult,
   ContentWageListFilter,
-  CustomContentWageCalculateInput,
-  CustomContentWageCalculateResult,
 } from "./wage.dto";
 import { ContentWage } from "./wage.object";
 
@@ -56,9 +56,9 @@ export class WageResolver {
 
     const promises = contents.map(async (content) => {
       return await this.contentWageService.getContentWage(content.id, {
-        includeIsBound: filter?.includeIsBound,
-        includeIsSeeMore: filter?.includeIsSeeMore,
+        includeBound: filter?.includeBound,
         includeItemIds: filter?.includeItemIds,
+        includeSeeMore: filter?.includeSeeMore,
       });
     });
 
@@ -73,8 +73,8 @@ export class WageResolver {
     return result;
   }
 
-  @Mutation(() => CustomContentWageCalculateResult)
-  async customContentWageCalculate(@Args("input") input: CustomContentWageCalculateInput) {
+  @Mutation(() => CalculateCustomContentWageResult)
+  async customContentWageCalculate(@Args("input") input: CalculateCustomContentWageInput) {
     const { items, minutes, seconds } = input;
 
     const totalSeconds = this.contentDurationService.getValidatedTotalSeconds({

--- a/src/backend/src/content/wage/wage.service.spec.ts
+++ b/src/backend/src/content/wage/wage.service.spec.ts
@@ -596,7 +596,7 @@ describe("ContentWageService", () => {
 
     it("다중 컨텐츠 수익 합산 정확성 검증", async () => {
       const contentIds = [testContents[0].id, testContents[1].id];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       const result = await service.getContentGroupWage(contentIds, filter);
 
@@ -642,7 +642,7 @@ describe("ContentWageService", () => {
       };
 
       const contentIds = [testContents[0].id];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       const result = await service.getContentGroupWage(contentIds, filter);
 
@@ -672,7 +672,7 @@ describe("ContentWageService", () => {
       });
 
       const contentIds = [testContents[0].id];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       const result = await service.getContentGroupWage(contentIds, filter);
 
@@ -686,7 +686,7 @@ describe("ContentWageService", () => {
 
     it("빈 배열 입력 시 처리", async () => {
       const contentIds = [];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       const result = await service.getContentGroupWage(contentIds, filter);
 
@@ -733,7 +733,7 @@ describe("ContentWageService", () => {
       ]);
 
       const contentIds = [mixedContent.id];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       const result = await service.getContentGroupWage(contentIds, filter);
 
@@ -749,7 +749,7 @@ describe("ContentWageService", () => {
       userGoldExchangeRateService["context"].req.user = { id: undefined };
 
       const contentIds = [testContents[0].id];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       // 환율 데이터가 없으면 에러가 발생해야 함
       await expect(service.getContentGroupWage(contentIds, filter)).rejects.toThrow();
@@ -766,7 +766,7 @@ describe("ContentWageService", () => {
     it("null/undefined 컨텐츠 필터링", async () => {
       const validContentId = testContents[0].id;
       const invalidContentIds = [null, undefined, validContentId, null];
-      const filter = { includeIsBound: false };
+      const filter = { includeBound: false };
 
       // null/undefined가 포함된 배열은 에러를 발생시켜야 함
       await expect(service.getContentGroupWage(invalidContentIds as any, filter)).rejects.toThrow();

--- a/src/backend/src/content/wage/wage.service.ts
+++ b/src/backend/src/content/wage/wage.service.ts
@@ -69,9 +69,9 @@ export class ContentWageService {
   async getContentGroupWage(
     contentIds: number[],
     filter: {
-      includeIsBound?: boolean;
-      includeIsSeeMore?: boolean;
+      includeBound?: boolean;
       includeItemIds?: number[];
+      includeSeeMore?: boolean;
     }
   ) {
     let totalGold = 0;
@@ -83,7 +83,7 @@ export class ContentWageService {
       });
 
       const rewards = await this.userContentService.getContentRewards(content.id, {
-        includeIsBound: filter?.includeIsBound,
+        includeBound: filter?.includeBound,
         includeItemIds: filter?.includeItemIds,
       });
 
@@ -94,7 +94,7 @@ export class ContentWageService {
       const rewardsGold = await this.calculateGold(rewards);
 
       const shouldIncludeSeeMoreRewards =
-        filter?.includeIsSeeMore && filter?.includeIsBound !== false && seeMoreRewards.length > 0;
+        filter?.includeSeeMore && filter?.includeBound !== false && seeMoreRewards.length > 0;
 
       const seeMoreGold = shouldIncludeSeeMoreRewards
         ? await this.calculateSeeMoreRewardsGold(seeMoreRewards, filter.includeItemIds)
@@ -123,9 +123,9 @@ export class ContentWageService {
   async getContentWage(
     contentId: number,
     filter: {
-      includeIsBound?: boolean;
-      includeIsSeeMore?: boolean;
+      includeBound?: boolean;
       includeItemIds?: number[];
+      includeSeeMore?: boolean;
     }
   ) {
     const content = await this.prisma.content.findUniqueOrThrow({
@@ -133,7 +133,7 @@ export class ContentWageService {
     });
 
     const rewards = await this.userContentService.getContentRewards(content.id, {
-      includeIsBound: filter?.includeIsBound,
+      includeBound: filter?.includeBound,
       includeItemIds: filter?.includeItemIds,
     });
 
@@ -144,7 +144,7 @@ export class ContentWageService {
     const rewardsGold = await this.calculateGold(rewards);
 
     const shouldIncludeSeeMoreRewards =
-      filter?.includeIsSeeMore && filter?.includeIsBound !== false && seeMoreRewards.length > 0;
+      filter?.includeSeeMore && filter?.includeBound !== false && seeMoreRewards.length > 0;
 
     const seeMoreGold = shouldIncludeSeeMoreRewards
       ? await this.calculateSeeMoreRewardsGold(seeMoreRewards, filter.includeItemIds)

--- a/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
@@ -1,13 +1,13 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
 
 @InputType()
-export class GoldExchangeRateEditInput {
-  @Field(() => Int)
+export class EditGoldExchangeRateInput {
+  @Field(() => Int, { description: "100골드당 원화 금액" })
   krwAmount: number;
 }
 
 @ObjectType()
-export class GoldExchangeRateEditResult {
-  @Field(() => Boolean)
+export class EditGoldExchangeRateResult {
+  @Field(() => Boolean, { description: "성공 여부" })
   ok: boolean;
 }

--- a/src/backend/src/exchange-rate/gold-exchange-rate.resolver.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.resolver.ts
@@ -4,7 +4,7 @@ import { AuthGuard } from "src/auth/auth.guard";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
 import { UserGoldExchangeRateService } from "src/user/service/user-gold-exchange-rate.service";
-import { GoldExchangeRateEditInput, GoldExchangeRateEditResult } from "./gold-exchange-rate.dto";
+import { EditGoldExchangeRateInput, EditGoldExchangeRateResult } from "./gold-exchange-rate.dto";
 import { GoldExchangeRate } from "./gold-exchange-rate.object";
 import { GoldExchangeRateService } from "./gold-exchange-rate.service";
 
@@ -21,9 +21,9 @@ export class GoldExchangeRateResolver {
   }
 
   @UseGuards(AuthGuard)
-  @Mutation(() => GoldExchangeRateEditResult)
+  @Mutation(() => EditGoldExchangeRateResult)
   async goldExchangeRateEdit(
-    @Args("input") input: GoldExchangeRateEditInput,
+    @Args("input") input: EditGoldExchangeRateInput,
     @CurrentUser() user: User
   ) {
     return await this.goldExchangeRateService.editGoldExchangeRate(input.krwAmount, user);

--- a/src/backend/src/item/auction-item/auction-item.dto.ts
+++ b/src/backend/src/item/auction-item/auction-item.dto.ts
@@ -2,9 +2,15 @@ import { Field, InputType } from "@nestjs/graphql";
 
 @InputType()
 export class AuctionItemListFilter {
-  @Field(() => Boolean, { nullable: true })
+  @Field(() => Boolean, {
+    description: "가격 통계 수집 활성화 여부",
+    nullable: true,
+  })
   isStatScraperEnabled?: boolean;
 
-  @Field(() => String, { nullable: true })
+  @Field(() => String, {
+    description: "아이템 이름 검색 키워드",
+    nullable: true,
+  })
   nameKeyword?: string;
 }

--- a/src/backend/src/item/market-item/market-item.dto.ts
+++ b/src/backend/src/item/market-item/market-item.dto.ts
@@ -2,15 +2,18 @@ import { Field, InputType } from "@nestjs/graphql";
 
 @InputType()
 export class MarketItemListFilter {
-  @Field({ nullable: true })
+  @Field({ description: "카테고리 이름", nullable: true })
   categoryName?: string;
 
-  @Field({ nullable: true })
+  @Field({ description: "등급", nullable: true })
   grade?: string;
 
-  @Field(() => Boolean, { nullable: true })
+  @Field(() => Boolean, {
+    description: "가격 통계 수집 활성화 여부",
+    nullable: true,
+  })
   isStatScraperEnabled?: boolean;
 
-  @Field({ nullable: true })
+  @Field({ description: "검색 키워드", nullable: true })
   keyword?: string;
 }

--- a/src/backend/src/user/service/user-content.service.spec.ts
+++ b/src/backend/src/user/service/user-content.service.spec.ts
@@ -168,7 +168,7 @@ describe("UserContentService", () => {
       });
 
       const results = await service.getContentRewards(content.id, {
-        includeIsBound: false,
+        includeBound: false,
       });
 
       expect(results).toHaveLength(1);
@@ -265,7 +265,7 @@ describe("UserContentService", () => {
       });
 
       const results = await service.getContentRewards(content.id, {
-        includeIsBound: false,
+        includeBound: false,
         includeItemIds: [item1.id, item2.id],
       });
 
@@ -487,7 +487,7 @@ describe("UserContentService", () => {
       });
 
       const results = await service.getContentRewards(content.id, {
-        includeIsBound: false,
+        includeBound: false,
       });
 
       expect(results).toHaveLength(1);

--- a/src/backend/src/user/service/user-content.service.ts
+++ b/src/backend/src/user/service/user-content.service.ts
@@ -90,7 +90,7 @@ export class UserContentService {
   async getContentRewards(
     contentId: number,
     filter?: {
-      includeIsBound?: boolean;
+      includeBound?: boolean;
       includeItemIds?: number[];
     }
   ) {
@@ -152,7 +152,7 @@ export class UserContentService {
     }
 
     return result.filter((item) => {
-      if (filter?.includeIsBound === false) {
+      if (filter?.includeBound === false) {
         return item.isSellable;
       }
       return true;

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -29,7 +29,9 @@ export type AuctionItem = {
 };
 
 export type AuctionItemListFilter = {
+  /** 가격 통계 수집 활성화 여부 */
   isStatScraperEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 아이템 이름 검색 키워드 */
   nameKeyword?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -39,9 +41,38 @@ export enum AuthProvider {
   KAKAO = 'KAKAO'
 }
 
+export type CalculateCustomContentWageInput = {
+  /** 아이템 목록 */
+  items: Array<CalculateCustomContentWageItemInput>;
+  /** 분 */
+  minutes: Scalars['Int']['input'];
+  /** 초 */
+  seconds: Scalars['Int']['input'];
+};
+
+export type CalculateCustomContentWageItemInput = {
+  /** 아이템 ID */
+  id: Scalars['Int']['input'];
+  /** 획득 수량 */
+  quantity: Scalars['Float']['input'];
+};
+
+export type CalculateCustomContentWageResult = {
+  __typename?: 'CalculateCustomContentWageResult';
+  /** 회당 골드 획득량 */
+  goldAmountPerClear: Scalars['Int']['output'];
+  /** 시급 (골드) */
+  goldAmountPerHour: Scalars['Int']['output'];
+  /** 시급 (원화) */
+  krwAmountPerHour: Scalars['Int']['output'];
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
 export type Content = {
   __typename?: 'Content';
   contentCategory: ContentCategory;
+  /** 컨텐츠 카테고리 ID */
   contentCategoryId: Scalars['Int']['output'];
   contentRewards: Array<ContentReward>;
   contentSeeMoreRewards: Array<ContentSeeMoreReward>;
@@ -49,12 +80,16 @@ export type Content = {
   displayName: Scalars['String']['output'];
   duration: Scalars['Int']['output'];
   durationText: Scalars['String']['output'];
+  /** 관문 번호 */
   gate?: Maybe<Scalars['Int']['output']>;
   id: Scalars['Int']['output'];
+  /** 레벨 */
   level: Scalars['Int']['output'];
+  /** 컨텐츠 이름 */
   name: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
   wage: ContentWage;
+  /** 시급 계산 필터 */
   wageFilter?: Maybe<ContentObjectWageFilter>;
 };
 
@@ -72,32 +107,6 @@ export type ContentCategory = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
-export type ContentCreateInput = {
-  categoryId: Scalars['Int']['input'];
-  contentRewards: Array<ContentCreateItemsInput>;
-  contentSeeMoreRewards?: InputMaybe<Array<ContentCreateSeeMoreRewardsInput>>;
-  duration: Scalars['Int']['input'];
-  gate?: InputMaybe<Scalars['Int']['input']>;
-  level: Scalars['Int']['input'];
-  name: Scalars['String']['input'];
-};
-
-export type ContentCreateItemsInput = {
-  averageQuantity: Scalars['Float']['input'];
-  isBound: Scalars['Boolean']['input'];
-  itemId: Scalars['Int']['input'];
-};
-
-export type ContentCreateResult = {
-  __typename?: 'ContentCreateResult';
-  ok: Scalars['Boolean']['output'];
-};
-
-export type ContentCreateSeeMoreRewardsInput = {
-  itemId: Scalars['Int']['input'];
-  quantity: Scalars['Float']['input'];
-};
-
 export type ContentDuration = {
   __typename?: 'ContentDuration';
   content: Content;
@@ -106,32 +115,6 @@ export type ContentDuration = {
   id: Scalars['Int']['output'];
   updatedAt: Scalars['DateTime']['output'];
   value: Scalars['Int']['output'];
-};
-
-export type ContentDurationEditInput = {
-  contentId: Scalars['Int']['input'];
-  minutes: Scalars['Int']['input'];
-  seconds: Scalars['Int']['input'];
-};
-
-export type ContentDurationEditResult = {
-  __typename?: 'ContentDurationEditResult';
-  ok: Scalars['Boolean']['output'];
-};
-
-export type ContentDurationsEditInput = {
-  contentDurations: Array<ContentDurationsEditInputDuration>;
-};
-
-export type ContentDurationsEditInputDuration = {
-  contentId: Scalars['Int']['input'];
-  minutes: Scalars['Int']['input'];
-  seconds: Scalars['Int']['input'];
-};
-
-export type ContentDurationsEditResult = {
-  __typename?: 'ContentDurationsEditResult';
-  ok: Scalars['Boolean']['output'];
 };
 
 export type ContentGroup = {
@@ -147,6 +130,7 @@ export type ContentGroup = {
 };
 
 export type ContentGroupFilter = {
+  /** 그룹화할 컨텐츠 ID 목록 */
   contentIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
@@ -159,26 +143,39 @@ export type ContentGroupWage = {
 };
 
 export type ContentGroupWageListFilter = {
+  /** 필터링할 컨텐츠 카테고리 ID */
   contentCategoryId?: InputMaybe<Scalars['Int']['input']>;
-  includeIsBound?: InputMaybe<Scalars['Boolean']['input']>;
-  includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 귀속 아이템 포함 여부 */
+  includeBound?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 포함할 아이템 ID 목록 */
   includeItemIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  /** 추가 보상(더보기) 포함 여부 */
+  includeSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 검색 키워드 */
   keyword?: InputMaybe<Scalars['String']['input']>;
+  /** 컨텐츠 상태 */
   status?: InputMaybe<ContentStatus>;
 };
 
 export type ContentListFilter = {
+  /** 필터링할 컨텐츠 카테고리 ID */
   contentCategoryId?: InputMaybe<Scalars['Int']['input']>;
-  includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 추가 보상(더보기) 포함 여부 */
+  includeSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 검색 키워드 */
   keyword?: InputMaybe<Scalars['String']['input']>;
+  /** 컨텐츠 상태 */
   status?: InputMaybe<ContentStatus>;
 };
 
 export type ContentObjectWageFilter = {
   __typename?: 'ContentObjectWageFilter';
-  includeIsBound?: Maybe<Scalars['Boolean']['output']>;
-  includeIsSeeMore?: Maybe<Scalars['Boolean']['output']>;
+  /** 귀속 아이템 포함 여부 */
+  includeBound?: Maybe<Scalars['Boolean']['output']>;
+  /** 포함할 아이템 ID 목록 */
   includeItemIds?: Maybe<Array<Scalars['String']['output']>>;
+  /** 추가 보상(더보기) 포함 여부 */
+  includeSeeMore?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type ContentReward = {
@@ -192,37 +189,6 @@ export type ContentReward = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
-export type ContentRewardEditInput = {
-  averageQuantity: Scalars['Float']['input'];
-  contentId: Scalars['Int']['input'];
-  isSellable: Scalars['Boolean']['input'];
-  itemId: Scalars['Int']['input'];
-};
-
-export type ContentRewardReportInput = {
-  averageQuantity: Scalars['Float']['input'];
-  id: Scalars['Int']['input'];
-};
-
-export type ContentRewardsEditInput = {
-  contentRewards: Array<ContentRewardEditInput>;
-  isReportable: Scalars['Boolean']['input'];
-};
-
-export type ContentRewardsEditResult = {
-  __typename?: 'ContentRewardsEditResult';
-  ok: Scalars['Boolean']['output'];
-};
-
-export type ContentRewardsReportInput = {
-  contentRewards: Array<ContentRewardReportInput>;
-};
-
-export type ContentRewardsReportResult = {
-  __typename?: 'ContentRewardsReportResult';
-  ok: Scalars['Boolean']['output'];
-};
-
 export type ContentSeeMoreReward = {
   __typename?: 'ContentSeeMoreReward';
   contentId: Scalars['Int']['output'];
@@ -232,21 +198,6 @@ export type ContentSeeMoreReward = {
   itemId: Scalars['Int']['output'];
   quantity: Scalars['Float']['output'];
   updatedAt: Scalars['DateTime']['output'];
-};
-
-export type ContentSeeMoreRewardEditInput = {
-  contentId: Scalars['Int']['input'];
-  itemId: Scalars['Int']['input'];
-  quantity: Scalars['Float']['input'];
-};
-
-export type ContentSeeMoreRewardsEditInput = {
-  contentSeeMoreRewards: Array<ContentSeeMoreRewardEditInput>;
-};
-
-export type ContentSeeMoreRewardsEditResult = {
-  __typename?: 'ContentSeeMoreRewardsEditResult';
-  ok: Scalars['Boolean']['output'];
 };
 
 export enum ContentStatus {
@@ -264,40 +215,173 @@ export type ContentWage = {
 };
 
 export type ContentWageFilter = {
-  includeIsBound?: InputMaybe<Scalars['Boolean']['input']>;
-  includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 귀속 아이템 포함 여부 */
+  includeBound?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 포함할 아이템 ID 목록 */
   includeItemIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  /** 추가 보상(더보기) 포함 여부 */
+  includeSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ContentWageListFilter = {
+  /** 필터링할 컨텐츠 카테고리 ID */
   contentCategoryId?: InputMaybe<Scalars['Int']['input']>;
-  includeIsBound?: InputMaybe<Scalars['Boolean']['input']>;
-  includeIsSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 귀속 아이템 포함 여부 */
+  includeBound?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 포함할 아이템 ID 목록 */
   includeItemIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  /** 추가 보상(더보기) 포함 여부 */
+  includeSeeMore?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 검색 키워드 */
   keyword?: InputMaybe<Scalars['String']['input']>;
+  /** 컨텐츠 상태 */
   status?: InputMaybe<ContentStatus>;
 };
 
 export type ContentsFilter = {
+  /** 필터링할 컨텐츠 ID 목록 */
   ids?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
-export type CustomContentWageCalculateInput = {
-  items: Array<CustomContentWageCalculateItemsInput>;
-  minutes: Scalars['Int']['input'];
-  seconds: Scalars['Int']['input'];
+export type CreateContentInput = {
+  /** 컨텐츠 카테고리 ID */
+  categoryId: Scalars['Int']['input'];
+  /** 컨텐츠 보상 아이템 목록 */
+  contentRewards: Array<CreateContentItemInput>;
+  /** 추가 보상(더보기) 아이템 목록 */
+  contentSeeMoreRewards?: InputMaybe<Array<CreateContentSeeMoreRewardInput>>;
+  /** 소요 시간 (초) */
+  duration: Scalars['Int']['input'];
+  /** 관문 번호 */
+  gate?: InputMaybe<Scalars['Int']['input']>;
+  /** 레벨 */
+  level: Scalars['Int']['input'];
+  /** 컨텐츠 이름 */
+  name: Scalars['String']['input'];
 };
 
-export type CustomContentWageCalculateItemsInput = {
-  id: Scalars['Int']['input'];
+export type CreateContentItemInput = {
+  /** 평균 획득 수량 */
+  averageQuantity: Scalars['Float']['input'];
+  /** 귀속 여부 */
+  isBound: Scalars['Boolean']['input'];
+  /** 아이템 ID */
+  itemId: Scalars['Int']['input'];
+};
+
+export type CreateContentResult = {
+  __typename?: 'CreateContentResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type CreateContentSeeMoreRewardInput = {
+  /** 아이템 ID */
+  itemId: Scalars['Int']['input'];
+  /** 획득 수량 */
   quantity: Scalars['Float']['input'];
 };
 
-export type CustomContentWageCalculateResult = {
-  __typename?: 'CustomContentWageCalculateResult';
-  goldAmountPerClear: Scalars['Int']['output'];
-  goldAmountPerHour: Scalars['Int']['output'];
-  krwAmountPerHour: Scalars['Int']['output'];
+export type EditContentDurationInput = {
+  /** 컨텐츠 ID */
+  contentId: Scalars['Int']['input'];
+  /** 분 */
+  minutes: Scalars['Int']['input'];
+  /** 초 */
+  seconds: Scalars['Int']['input'];
+};
+
+export type EditContentDurationResult = {
+  __typename?: 'EditContentDurationResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type EditContentDurationsDurationInput = {
+  /** 컨텐츠 ID */
+  contentId: Scalars['Int']['input'];
+  /** 분 */
+  minutes: Scalars['Int']['input'];
+  /** 초 */
+  seconds: Scalars['Int']['input'];
+};
+
+export type EditContentDurationsInput = {
+  /** 수정할 컨텐츠 소요 시간 목록 */
+  contentDurations: Array<EditContentDurationsDurationInput>;
+};
+
+export type EditContentDurationsResult = {
+  __typename?: 'EditContentDurationsResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type EditContentRewardInput = {
+  /** 평균 획득 수량 */
+  averageQuantity: Scalars['Float']['input'];
+  /** 컨텐츠 ID */
+  contentId: Scalars['Int']['input'];
+  /** 거래 가능 여부 */
+  isSellable: Scalars['Boolean']['input'];
+  /** 아이템 ID */
+  itemId: Scalars['Int']['input'];
+};
+
+export type EditContentRewardsInput = {
+  /** 수정할 컨텐츠 보상 목록 */
+  contentRewards: Array<EditContentRewardInput>;
+  /** 제보 가능 여부 */
+  isReportable: Scalars['Boolean']['input'];
+};
+
+export type EditContentRewardsResult = {
+  __typename?: 'EditContentRewardsResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type EditContentSeeMoreRewardInput = {
+  /** 컨텐츠 ID */
+  contentId: Scalars['Int']['input'];
+  /** 아이템 ID */
+  itemId: Scalars['Int']['input'];
+  /** 획득 수량 */
+  quantity: Scalars['Float']['input'];
+};
+
+export type EditContentSeeMoreRewardsInput = {
+  /** 수정할 추가 보상(더보기) 목록 */
+  contentSeeMoreRewards: Array<EditContentSeeMoreRewardInput>;
+};
+
+export type EditContentSeeMoreRewardsResult = {
+  __typename?: 'EditContentSeeMoreRewardsResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type EditGoldExchangeRateInput = {
+  /** 100골드당 원화 금액 */
+  krwAmount: Scalars['Int']['input'];
+};
+
+export type EditGoldExchangeRateResult = {
+  __typename?: 'EditGoldExchangeRateResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type EditUserItemPriceInput = {
+  /** 아이템 ID */
+  id: Scalars['Int']['input'];
+  /** 사용자 지정 가격 */
+  price: Scalars['Float']['input'];
+};
+
+export type EditUserItemPriceResult = {
+  __typename?: 'EditUserItemPriceResult';
+  /** 성공 여부 */
   ok: Scalars['Boolean']['output'];
 };
 
@@ -308,15 +392,6 @@ export type GoldExchangeRate = {
   id: Scalars['Int']['output'];
   krwAmount: Scalars['Float']['output'];
   updatedAt: Scalars['DateTime']['output'];
-};
-
-export type GoldExchangeRateEditInput = {
-  krwAmount: Scalars['Int']['input'];
-};
-
-export type GoldExchangeRateEditResult = {
-  __typename?: 'GoldExchangeRateEditResult';
-  ok: Scalars['Boolean']['output'];
 };
 
 export type Item = {
@@ -338,7 +413,9 @@ export enum ItemKind {
 }
 
 export type ItemsFilter = {
+  /** 제외할 아이템 이름 */
   excludeItemName?: InputMaybe<Scalars['String']['input']>;
+  /** 아이템 종류 */
   kind?: InputMaybe<ItemKind>;
 };
 
@@ -358,68 +435,72 @@ export type MarketItem = {
 };
 
 export type MarketItemListFilter = {
+  /** 카테고리 이름 */
   categoryName?: InputMaybe<Scalars['String']['input']>;
+  /** 등급 */
   grade?: InputMaybe<Scalars['String']['input']>;
+  /** 가격 통계 수집 활성화 여부 */
   isStatScraperEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  /** 검색 키워드 */
   keyword?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
-  contentCreate: ContentCreateResult;
-  contentDurationEdit: ContentDurationEditResult;
-  contentDurationsEdit: ContentDurationsEditResult;
-  contentRewardsEdit: ContentRewardsEditResult;
-  contentRewardsReport: ContentRewardsReportResult;
-  contentSeeMoreRewardsEdit: ContentSeeMoreRewardsEditResult;
-  customContentWageCalculate: CustomContentWageCalculateResult;
-  goldExchangeRateEdit: GoldExchangeRateEditResult;
-  userItemPriceEdit: UserItemPriceEditResult;
+  contentCreate: CreateContentResult;
+  contentDurationEdit: EditContentDurationResult;
+  contentDurationsEdit: EditContentDurationsResult;
+  contentRewardsEdit: EditContentRewardsResult;
+  contentRewardsReport: ReportContentRewardsResult;
+  contentSeeMoreRewardsEdit: EditContentSeeMoreRewardsResult;
+  customContentWageCalculate: CalculateCustomContentWageResult;
+  goldExchangeRateEdit: EditGoldExchangeRateResult;
+  userItemPriceEdit: EditUserItemPriceResult;
 };
 
 
 export type MutationContentCreateArgs = {
-  input: ContentCreateInput;
+  input: CreateContentInput;
 };
 
 
 export type MutationContentDurationEditArgs = {
-  input: ContentDurationEditInput;
+  input: EditContentDurationInput;
 };
 
 
 export type MutationContentDurationsEditArgs = {
-  input: ContentDurationsEditInput;
+  input: EditContentDurationsInput;
 };
 
 
 export type MutationContentRewardsEditArgs = {
-  input: ContentRewardsEditInput;
+  input: EditContentRewardsInput;
 };
 
 
 export type MutationContentRewardsReportArgs = {
-  input: ContentRewardsReportInput;
+  input: ReportContentRewardsInput;
 };
 
 
 export type MutationContentSeeMoreRewardsEditArgs = {
-  input: ContentSeeMoreRewardsEditInput;
+  input: EditContentSeeMoreRewardsInput;
 };
 
 
 export type MutationCustomContentWageCalculateArgs = {
-  input: CustomContentWageCalculateInput;
+  input: CalculateCustomContentWageInput;
 };
 
 
 export type MutationGoldExchangeRateEditArgs = {
-  input: GoldExchangeRateEditInput;
+  input: EditGoldExchangeRateInput;
 };
 
 
 export type MutationUserItemPriceEditArgs = {
-  input: UserItemPriceEditInput;
+  input: EditUserItemPriceInput;
 };
 
 export type OrderByArg = {
@@ -516,6 +597,24 @@ export type QueryMarketItemsArgs = {
   take?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type ReportContentRewardInput = {
+  /** 평균 획득 수량 */
+  averageQuantity: Scalars['Float']['input'];
+  /** 컨텐츠 보상 ID */
+  id: Scalars['Int']['input'];
+};
+
+export type ReportContentRewardsInput = {
+  /** 제보할 컨텐츠 보상 목록 */
+  contentRewards: Array<ReportContentRewardInput>;
+};
+
+export type ReportContentRewardsResult = {
+  __typename?: 'ReportContentRewardsResult';
+  /** 성공 여부 */
+  ok: Scalars['Boolean']['output'];
+};
+
 export type User = {
   __typename?: 'User';
   createdAt: Scalars['DateTime']['output'];
@@ -539,16 +638,6 @@ export type UserItem = {
   userId: Scalars['Int']['output'];
 };
 
-export type UserItemPriceEditInput = {
-  id: Scalars['Int']['input'];
-  price: Scalars['Float']['input'];
-};
-
-export type UserItemPriceEditResult = {
-  __typename?: 'UserItemPriceEditResult';
-  ok: Scalars['Boolean']['output'];
-};
-
 export enum UserRole {
   ADMIN = 'ADMIN',
   OWNER = 'OWNER',
@@ -561,11 +650,11 @@ export type ContentCreateTabDataQueryVariables = Exact<{ [key: string]: never; }
 export type ContentCreateTabDataQuery = { __typename?: 'Query', contentCategories: Array<{ __typename?: 'ContentCategory', id: number, name: string }>, items: Array<{ __typename?: 'Item', id: number, name: string }> };
 
 export type ContentCreateTabMutationVariables = Exact<{
-  input: ContentCreateInput;
+  input: CreateContentInput;
 }>;
 
 
-export type ContentCreateTabMutation = { __typename?: 'Mutation', contentCreate: { __typename?: 'ContentCreateResult', ok: boolean } };
+export type ContentCreateTabMutation = { __typename?: 'Mutation', contentCreate: { __typename?: 'CreateContentResult', ok: boolean } };
 
 export type PredictRewardsTabQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -614,11 +703,11 @@ export type CustomContentWageCalculateDialogQueryQueryVariables = Exact<{ [key: 
 export type CustomContentWageCalculateDialogQueryQuery = { __typename?: 'Query', items: Array<{ __typename?: 'Item', id: number, name: string }> };
 
 export type CustomContentWageCalculateDialogMutationMutationVariables = Exact<{
-  input: CustomContentWageCalculateInput;
+  input: CalculateCustomContentWageInput;
 }>;
 
 
-export type CustomContentWageCalculateDialogMutationMutation = { __typename?: 'Mutation', customContentWageCalculate: { __typename?: 'CustomContentWageCalculateResult', krwAmountPerHour: number, goldAmountPerHour: number, goldAmountPerClear: number, ok: boolean } };
+export type CustomContentWageCalculateDialogMutationMutation = { __typename?: 'Mutation', customContentWageCalculate: { __typename?: 'CalculateCustomContentWageResult', krwAmountPerHour: number, goldAmountPerHour: number, goldAmountPerClear: number, ok: boolean } };
 
 export type GoldExchangeRateSettingDialogQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -626,11 +715,11 @@ export type GoldExchangeRateSettingDialogQueryVariables = Exact<{ [key: string]:
 export type GoldExchangeRateSettingDialogQuery = { __typename?: 'Query', goldExchangeRate: { __typename?: 'GoldExchangeRate', id: number, krwAmount: number, goldAmount: number } };
 
 export type GoldExchangeRateEditMutationVariables = Exact<{
-  input: GoldExchangeRateEditInput;
+  input: EditGoldExchangeRateInput;
 }>;
 
 
-export type GoldExchangeRateEditMutation = { __typename?: 'Mutation', goldExchangeRateEdit: { __typename?: 'GoldExchangeRateEditResult', ok: boolean } };
+export type GoldExchangeRateEditMutation = { __typename?: 'Mutation', goldExchangeRateEdit: { __typename?: 'EditGoldExchangeRateResult', ok: boolean } };
 
 export type ContentWageListQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -661,11 +750,11 @@ export type UserExtraItemPriceEditDialogQueryVariables = Exact<{
 export type UserExtraItemPriceEditDialogQuery = { __typename?: 'Query', item: { __typename?: 'Item', name: string, userItem: { __typename?: 'UserItem', id: number, price: number } } };
 
 export type UserItemPriceEditMutationVariables = Exact<{
-  input: UserItemPriceEditInput;
+  input: EditUserItemPriceInput;
 }>;
 
 
-export type UserItemPriceEditMutation = { __typename?: 'Mutation', userItemPriceEdit: { __typename?: 'UserItemPriceEditResult', ok: boolean } };
+export type UserItemPriceEditMutation = { __typename?: 'Mutation', userItemPriceEdit: { __typename?: 'EditUserItemPriceResult', ok: boolean } };
 
 export type MarketItemListTableQueryVariables = Exact<{
   filter?: InputMaybe<MarketItemListFilter>;
@@ -704,11 +793,11 @@ export type ContentDurationEditDialogQueryVariables = Exact<{
 export type ContentDurationEditDialogQuery = { __typename?: 'Query', content: { __typename?: 'Content', displayName: string, duration: number } };
 
 export type ContentDurationEditMutationVariables = Exact<{
-  input: ContentDurationEditInput;
+  input: EditContentDurationInput;
 }>;
 
 
-export type ContentDurationEditMutation = { __typename?: 'Mutation', contentDurationEdit: { __typename?: 'ContentDurationEditResult', ok: boolean } };
+export type ContentDurationEditMutation = { __typename?: 'Mutation', contentDurationEdit: { __typename?: 'EditContentDurationResult', ok: boolean } };
 
 export type ContentGroupDetailsDialogQueryVariables = Exact<{
   contentIds: Array<Scalars['Int']['input']> | Scalars['Int']['input'];
@@ -725,11 +814,11 @@ export type ContentGroupDurationEditDialogQueryVariables = Exact<{
 export type ContentGroupDurationEditDialogQuery = { __typename?: 'Query', contentGroup: { __typename?: 'ContentGroup', name: string }, contents: Array<{ __typename?: 'Content', duration: number, gate?: number | null, id: number }> };
 
 export type ContentDurationsEditMutationVariables = Exact<{
-  input: ContentDurationsEditInput;
+  input: EditContentDurationsInput;
 }>;
 
 
-export type ContentDurationsEditMutation = { __typename?: 'Mutation', contentDurationsEdit: { __typename?: 'ContentDurationsEditResult', ok: boolean } };
+export type ContentDurationsEditMutation = { __typename?: 'Mutation', contentDurationsEdit: { __typename?: 'EditContentDurationsResult', ok: boolean } };
 
 export type ContentRewardEditDialogQueryVariables = Exact<{
   id: Scalars['Int']['input'];
@@ -739,11 +828,11 @@ export type ContentRewardEditDialogQueryVariables = Exact<{
 export type ContentRewardEditDialogQuery = { __typename?: 'Query', content: { __typename?: 'Content', displayName: string, contentRewards: Array<{ __typename?: 'ContentReward', averageQuantity: number, id: number, isSellable: boolean, item: { __typename?: 'Item', id: number, name: string } }> } };
 
 export type ContentRewardsEditMutationVariables = Exact<{
-  input: ContentRewardsEditInput;
+  input: EditContentRewardsInput;
 }>;
 
 
-export type ContentRewardsEditMutation = { __typename?: 'Mutation', contentRewardsEdit: { __typename?: 'ContentRewardsEditResult', ok: boolean } };
+export type ContentRewardsEditMutation = { __typename?: 'Mutation', contentRewardsEdit: { __typename?: 'EditContentRewardsResult', ok: boolean } };
 
 export type ContentRewardReportDialogQueryVariables = Exact<{
   id: Scalars['Int']['input'];
@@ -753,11 +842,11 @@ export type ContentRewardReportDialogQueryVariables = Exact<{
 export type ContentRewardReportDialogQuery = { __typename?: 'Query', content: { __typename?: 'Content', contentRewards: Array<{ __typename?: 'ContentReward', averageQuantity: number, id: number, isSellable: boolean, item: { __typename?: 'Item', name: string } }> } };
 
 export type ContentRewardsReportMutationVariables = Exact<{
-  input: ContentRewardsReportInput;
+  input: ReportContentRewardsInput;
 }>;
 
 
-export type ContentRewardsReportMutation = { __typename?: 'Mutation', contentRewardsReport: { __typename?: 'ContentRewardsReportResult', ok: boolean } };
+export type ContentRewardsReportMutation = { __typename?: 'Mutation', contentRewardsReport: { __typename?: 'ReportContentRewardsResult', ok: boolean } };
 
 export type ContentSeeMoreRewardEditDialogQueryVariables = Exact<{
   id: Scalars['Int']['input'];
@@ -767,11 +856,11 @@ export type ContentSeeMoreRewardEditDialogQueryVariables = Exact<{
 export type ContentSeeMoreRewardEditDialogQuery = { __typename?: 'Query', content: { __typename?: 'Content', displayName: string, contentSeeMoreRewards: Array<{ __typename?: 'ContentSeeMoreReward', id: number, quantity: number, item: { __typename?: 'Item', id: number, name: string } }> } };
 
 export type ContentSeeMoreRewardsEditMutationVariables = Exact<{
-  input: ContentSeeMoreRewardsEditInput;
+  input: EditContentSeeMoreRewardsInput;
 }>;
 
 
-export type ContentSeeMoreRewardsEditMutation = { __typename?: 'Mutation', contentSeeMoreRewardsEdit: { __typename?: 'ContentSeeMoreRewardsEditResult', ok: boolean } };
+export type ContentSeeMoreRewardsEditMutation = { __typename?: 'Mutation', contentSeeMoreRewardsEdit: { __typename?: 'EditContentSeeMoreRewardsResult', ok: boolean } };
 
 export type ItemStatUpdateToggleTipQueryVariables = Exact<{
   take?: InputMaybe<Scalars['Int']['input']>;
@@ -783,7 +872,7 @@ export type ItemStatUpdateToggleTipQuery = { __typename?: 'Query', marketItems: 
 
 
 export const ContentCreateTabDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentCreateTabData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentCreateTabDataQuery, ContentCreateTabDataQueryVariables>;
-export const ContentCreateTabDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentCreateTab"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCreate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentCreateTabMutation, ContentCreateTabMutationVariables>;
+export const ContentCreateTabDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentCreateTab"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateContentInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCreate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentCreateTabMutation, ContentCreateTabMutationVariables>;
 export const PredictRewardsTabDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"PredictRewardsTab"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<PredictRewardsTabQuery, PredictRewardsTabQueryVariables>;
 export const UserListTabQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserListTabQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"provider"}},{"kind":"Field","name":{"kind":"Name","value":"refId"}}]}}]}}]} as unknown as DocumentNode<UserListTabQueryQuery, UserListTabQueryQueryVariables>;
 export const ValidateRewardsTabDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ValidateRewardsTab"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<ValidateRewardsTabQuery, ValidateRewardsTabQueryVariables>;
@@ -792,27 +881,27 @@ export const ContentGroupWageListTableDocument = {"kind":"Document","definitions
 export const ContentWageListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentWageListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentWageListFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentWageList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"durationText"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"level"}}]}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}}]}}]}}]} as unknown as DocumentNode<ContentWageListTableQuery, ContentWageListTableQueryVariables>;
 export const ItemsFilterDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ItemsFilter"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ItemsFilterQuery, ItemsFilterQueryVariables>;
 export const CustomContentWageCalculateDialogQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CustomContentWageCalculateDialogQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<CustomContentWageCalculateDialogQueryQuery, CustomContentWageCalculateDialogQueryQueryVariables>;
-export const CustomContentWageCalculateDialogMutationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CustomContentWageCalculateDialogMutation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CustomContentWageCalculateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customContentWageCalculate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}},{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<CustomContentWageCalculateDialogMutationMutation, CustomContentWageCalculateDialogMutationMutationVariables>;
+export const CustomContentWageCalculateDialogMutationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CustomContentWageCalculateDialogMutation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CalculateCustomContentWageInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customContentWageCalculate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}},{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<CustomContentWageCalculateDialogMutationMutation, CustomContentWageCalculateDialogMutationMutationVariables>;
 export const GoldExchangeRateSettingDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GoldExchangeRateSettingDialog"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"goldExchangeRate"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmount"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmount"}}]}}]}}]} as unknown as DocumentNode<GoldExchangeRateSettingDialogQuery, GoldExchangeRateSettingDialogQueryVariables>;
-export const GoldExchangeRateEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"GoldExchangeRateEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"GoldExchangeRateEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"goldExchangeRateEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<GoldExchangeRateEditMutation, GoldExchangeRateEditMutationVariables>;
+export const GoldExchangeRateEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"GoldExchangeRateEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditGoldExchangeRateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"goldExchangeRateEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<GoldExchangeRateEditMutation, GoldExchangeRateEditMutationVariables>;
 export const ContentWageListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentWageList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"goldExchangeRate"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"goldAmount"}},{"kind":"Field","name":{"kind":"Name","value":"krwAmount"}}]}}]}}]} as unknown as DocumentNode<ContentWageListQuery, ContentWageListQueryVariables>;
 export const AuctionItemListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AuctionItemListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"AuctionItemListFilter"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"take"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"OrderByArg"}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"auctionItemList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"avgBuyPrice"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"auctionItems"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"take"},"value":{"kind":"Variable","name":{"kind":"Name","value":"take"}}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<AuctionItemListTableQuery, AuctionItemListTableQueryVariables>;
 export const ExtraItemListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ExtraItemListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ItemsFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"price"}}]}}]}}]} as unknown as DocumentNode<ExtraItemListTableQuery, ExtraItemListTableQueryVariables>;
 export const UserExtraItemPriceEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserExtraItemPriceEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"item"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"userItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"price"}}]}}]}}]}}]} as unknown as DocumentNode<UserExtraItemPriceEditDialogQuery, UserExtraItemPriceEditDialogQueryVariables>;
-export const UserItemPriceEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UserItemPriceEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserItemPriceEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userItemPriceEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<UserItemPriceEditMutation, UserItemPriceEditMutationVariables>;
+export const UserItemPriceEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UserItemPriceEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditUserItemPriceInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userItemPriceEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<UserItemPriceEditMutation, UserItemPriceEditMutationVariables>;
 export const MarketItemListTableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MarketItemListTable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"MarketItemListFilter"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"take"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"OrderByArg"}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"marketItemList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"bundleCount"}},{"kind":"Field","name":{"kind":"Name","value":"currentMinPrice"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"recentPrice"}},{"kind":"Field","name":{"kind":"Name","value":"yDayAvgPrice"}}]}},{"kind":"Field","name":{"kind":"Name","value":"marketItems"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"take"},"value":{"kind":"Variable","name":{"kind":"Name","value":"take"}}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<MarketItemListTableQuery, MarketItemListTableQueryVariables>;
 export const ContentCategoriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategories"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentCategoriesQuery, ContentCategoriesQueryVariables>;
 export const ContentDetailsDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentDetailsDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentCategory"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"quantity"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"level"}}]}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentDetailsDialogQuery, ContentDetailsDialogQueryVariables>;
 export const ContentDetailsDialogWageSectionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentDetailsDialogWageSection"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"filter"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentWageFilter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"durationText"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"wage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"Variable","name":{"kind":"Name","value":"filter"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"krwAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerHour"}},{"kind":"Field","name":{"kind":"Name","value":"goldAmountPerClear"}}]}}]}}]}}]} as unknown as DocumentNode<ContentDetailsDialogWageSectionQuery, ContentDetailsDialogWageSectionQueryVariables>;
 export const ContentDurationEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentDurationEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"duration"}}]}}]}}]} as unknown as DocumentNode<ContentDurationEditDialogQuery, ContentDurationEditDialogQueryVariables>;
-export const ContentDurationEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentDurationEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentDurationEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDurationEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentDurationEditMutation, ContentDurationEditMutationVariables>;
+export const ContentDurationEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentDurationEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditContentDurationInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDurationEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentDurationEditMutation, ContentDurationEditMutationVariables>;
 export const ContentGroupDetailsDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentGroupDetailsDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"contentIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"contentIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"contentIds"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contents"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"gate"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ContentGroupDetailsDialogQuery, ContentGroupDetailsDialogQueryVariables>;
 export const ContentGroupDurationEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentGroupDurationEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentGroup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"contentIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"contents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"ids"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"gate"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<ContentGroupDurationEditDialogQuery, ContentGroupDurationEditDialogQueryVariables>;
-export const ContentDurationsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentDurationsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentDurationsEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDurationsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentDurationsEditMutation, ContentDurationsEditMutationVariables>;
+export const ContentDurationsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentDurationsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditContentDurationsInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentDurationsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentDurationsEditMutation, ContentDurationsEditMutationVariables>;
 export const ContentRewardEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<ContentRewardEditDialogQuery, ContentRewardEditDialogQueryVariables>;
-export const ContentRewardsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentRewardsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentRewardsEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentRewardsEditMutation, ContentRewardsEditMutationVariables>;
+export const ContentRewardsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentRewardsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditContentRewardsInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentRewardsEditMutation, ContentRewardsEditMutationVariables>;
 export const ContentRewardReportDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentRewardReportDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"averageQuantity"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"isSellable"}}]}}]}}]}}]} as unknown as DocumentNode<ContentRewardReportDialogQuery, ContentRewardReportDialogQueryVariables>;
-export const ContentRewardsReportDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentRewardsReport"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentRewardsReportInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardsReport"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentRewardsReportMutation, ContentRewardsReportMutationVariables>;
+export const ContentRewardsReportDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentRewardsReport"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ReportContentRewardsInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentRewardsReport"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentRewardsReportMutation, ContentRewardsReportMutationVariables>;
 export const ContentSeeMoreRewardEditDialogDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ContentSeeMoreRewardEditDialog"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewards"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"quantity"}}]}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<ContentSeeMoreRewardEditDialogQuery, ContentSeeMoreRewardEditDialogQueryVariables>;
-export const ContentSeeMoreRewardsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentSeeMoreRewardsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ContentSeeMoreRewardsEditInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewardsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentSeeMoreRewardsEditMutation, ContentSeeMoreRewardsEditMutationVariables>;
+export const ContentSeeMoreRewardsEditDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ContentSeeMoreRewardsEdit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditContentSeeMoreRewardsInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contentSeeMoreRewardsEdit"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ok"}}]}}]}}]} as unknown as DocumentNode<ContentSeeMoreRewardsEditMutation, ContentSeeMoreRewardsEditMutationVariables>;
 export const ItemStatUpdateToggleTipDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ItemStatUpdateToggleTip"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"take"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"OrderByArg"}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"marketItems"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"take"},"value":{"kind":"Variable","name":{"kind":"Name","value":"take"}}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"auctionItems"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"take"},"value":{"kind":"Variable","name":{"kind":"Name","value":"take"}}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"orderBy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<ItemStatUpdateToggleTipQuery, ItemStatUpdateToggleTipQueryVariables>;

--- a/src/frontend/src/pages/admin/tabs/content-create-tab/content-create-tab.graphql
+++ b/src/frontend/src/pages/admin/tabs/content-create-tab/content-create-tab.graphql
@@ -9,7 +9,7 @@ query ContentCreateTabData {
   }
 }
 
-mutation ContentCreateTab($input: ContentCreateInput!) {
+mutation ContentCreateTab($input: CreateContentInput!) {
   contentCreate(input: $input) {
     ok
   }

--- a/src/frontend/src/pages/admin/tabs/content-create-tab/content-create-tab.tsx
+++ b/src/frontend/src/pages/admin/tabs/content-create-tab/content-create-tab.tsx
@@ -5,7 +5,7 @@ import { toaster } from "~/core/chakra-components/ui/toaster";
 import { Form, z } from "~/core/form";
 import { useSafeQuery } from "~/core/graphql";
 import {
-  ContentCreateInput,
+  CreateContentInput,
   ContentCreateTabDataDocument,
   ContentCreateTabDocument,
   ContentCreateTabMutation,
@@ -40,7 +40,7 @@ export const ContentCreateTab = () => {
 
   return (
     <Section>
-      <Form.Mutation<ContentCreateInput, ContentCreateTabMutation>
+      <Form.Mutation<CreateContentInput, ContentCreateTabMutation>
         defaultValues={{
           contentRewards: data.items.map(({ id }) => ({
             averageQuantity: 0,

--- a/src/frontend/src/pages/content-wage-list/components/content-group-wage-list-table.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/content-group-wage-list-table.tsx
@@ -24,9 +24,9 @@ export const ContentGroupWageListTable = () => {
   const { isAuthenticated } = useAuth();
   const {
     contentCategoryId,
-    includeIsBound,
-    includeIsSeeMore,
+    includeBound,
     includeItemIds,
+    includeSeeMore,
     keyword,
     shouldMergeGate,
   } = useContentWageListPage();
@@ -43,9 +43,9 @@ export const ContentGroupWageListTable = () => {
     variables: {
       filter: {
         contentCategoryId,
-        includeIsBound,
-        includeIsSeeMore,
+        includeBound,
         includeItemIds,
+        includeSeeMore,
         keyword,
         status: ContentStatus.ACTIVE,
       },

--- a/src/frontend/src/pages/content-wage-list/components/content-wage-list-filters.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/content-wage-list-filters.tsx
@@ -77,7 +77,7 @@ export const ContentWageListFilters = () => {
 };
 
 const ContentSeeMoreFilter = () => {
-  const { includeIsSeeMore, setIncludeIsSeeMore } = useContentWageListPage();
+  const { includeSeeMore, setIncludeSeeMore } = useContentWageListPage();
 
   return (
     <SegmentedControl
@@ -85,14 +85,14 @@ const ContentSeeMoreFilter = () => {
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsSeeMore(e.value === "true")}
-      value={includeIsSeeMore ? "true" : "false"}
+      onValueChange={(e) => setIncludeSeeMore(e.value === "true")}
+      value={includeSeeMore ? "true" : "false"}
     />
   );
 };
 
 const ContentIsBoundFilter = () => {
-  const { includeIsBound, setIncludeIsBound } = useContentWageListPage();
+  const { includeBound, setIncludeBound } = useContentWageListPage();
 
   return (
     <SegmentedControl
@@ -100,8 +100,8 @@ const ContentIsBoundFilter = () => {
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsBound(e.value === "true")}
-      value={includeIsBound ? "true" : "false"}
+      onValueChange={(e) => setIncludeBound(e.value === "true")}
+      value={includeBound ? "true" : "false"}
     />
   );
 };

--- a/src/frontend/src/pages/content-wage-list/components/content-wage-list-table.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/content-wage-list-table.tsx
@@ -24,9 +24,9 @@ export const ContentWageListTable = () => {
   const { isAuthenticated } = useAuth();
   const {
     contentCategoryId,
-    includeIsBound,
-    includeIsSeeMore,
+    includeBound,
     includeItemIds,
+    includeSeeMore,
     keyword,
     shouldMergeGate,
   } = useContentWageListPage();
@@ -43,9 +43,9 @@ export const ContentWageListTable = () => {
     variables: {
       filter: {
         contentCategoryId,
-        includeIsBound,
-        includeIsSeeMore,
+        includeBound,
         includeItemIds,
+        includeSeeMore,
         keyword,
         status: ContentStatus.ACTIVE,
       },

--- a/src/frontend/src/pages/content-wage-list/components/custom-content-wage-calculate-dialog.graphql
+++ b/src/frontend/src/pages/content-wage-list/components/custom-content-wage-calculate-dialog.graphql
@@ -6,7 +6,7 @@ query CustomContentWageCalculateDialogQuery {
 }
 
 mutation CustomContentWageCalculateDialogMutation(
-  $input: CustomContentWageCalculateInput!
+  $input: CalculateCustomContentWageInput!
 ) {
   customContentWageCalculate(input: $input) {
     krwAmountPerHour

--- a/src/frontend/src/pages/content-wage-list/components/custom-content-wage-calculate-dialog.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/custom-content-wage-calculate-dialog.tsx
@@ -10,8 +10,8 @@ import {
   CustomContentWageCalculateDialogMutationDocument,
   CustomContentWageCalculateDialogMutationMutation,
   CustomContentWageCalculateDialogQueryDocument,
-  CustomContentWageCalculateInput,
-  CustomContentWageCalculateResult,
+  CalculateCustomContentWageInput,
+  CalculateCustomContentWageResult,
   CustomContentWageCalculateDialogQueryQuery,
 } from "~/core/graphql/generated";
 
@@ -27,11 +27,11 @@ const schema = z.object({
 });
 
 export const CustomContentWageCalculateDialog = (dialogProps: DialogProps) => {
-  const [result, setResult] = useState<CustomContentWageCalculateResult>();
+  const [result, setResult] = useState<CalculateCustomContentWageResult>();
 
   return (
     <Dialog<
-      CustomContentWageCalculateInput,
+      CalculateCustomContentWageInput,
       CustomContentWageCalculateDialogMutationMutation,
       CustomContentWageCalculateDialogQueryQuery
     >

--- a/src/frontend/src/pages/content-wage-list/components/gold-exchange-rate-setting-dialog.graphql
+++ b/src/frontend/src/pages/content-wage-list/components/gold-exchange-rate-setting-dialog.graphql
@@ -6,7 +6,7 @@ query GoldExchangeRateSettingDialog {
   }
 }
 
-mutation GoldExchangeRateEdit($input: GoldExchangeRateEditInput!) {
+mutation GoldExchangeRateEdit($input: EditGoldExchangeRateInput!) {
   goldExchangeRateEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/pages/content-wage-list/components/gold-exchange-rate-setting-dialog.tsx
+++ b/src/frontend/src/pages/content-wage-list/components/gold-exchange-rate-setting-dialog.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
 import {
   GoldExchangeRateEditDocument,
-  GoldExchangeRateEditInput,
+  EditGoldExchangeRateInput,
   GoldExchangeRateEditMutation,
   GoldExchangeRateSettingDialogDocument,
   GoldExchangeRateSettingDialogQuery,
@@ -21,7 +21,7 @@ export const GoldExchangeRateSettingDialog = ({
 } & DialogProps) => {
   return (
     <Dialog<
-      GoldExchangeRateEditInput,
+      EditGoldExchangeRateInput,
       GoldExchangeRateEditMutation,
       GoldExchangeRateSettingDialogQuery
     >

--- a/src/frontend/src/pages/content-wage-list/content-wage-list-page-context.tsx
+++ b/src/frontend/src/pages/content-wage-list/content-wage-list-page-context.tsx
@@ -13,19 +13,19 @@ import { ItemsFilterDocument, ItemsFilterQuery } from "~/core/graphql/generated"
 type ContentWageListPageContextType = {
   contentCategoryId: number | null;
 
-  includeIsBound?: boolean;
-  includeIsSeeMore?: boolean;
-
+  includeBound?: boolean;
   includeItemIds: number[];
+
+  includeSeeMore?: boolean;
   items: ItemsFilterQuery["items"];
 
   keyword: string;
   setContentCategoryId: (id: number | null) => void;
 
-  setIncludeIsBound: (value: boolean) => void;
-  setIncludeIsSeeMore: (value: boolean) => void;
-
+  setIncludeBound: (value: boolean) => void;
   setIncludeItemIds: Dispatch<SetStateAction<number[]>>;
+
+  setIncludeSeeMore: (value: boolean) => void;
   setKeyword: (value: string) => void;
 
   setShouldMergeGate: (value: boolean) => void;
@@ -42,8 +42,8 @@ export const ContentWageListPageProvider = ({ children }: PropsWithChildren) => 
   } = useSafeQuery(ItemsFilterDocument);
   const [contentCategoryId, setContentCategoryId] = useState<number | null>(null);
   const [keyword, setKeyword] = useState<string>("");
-  const [includeIsSeeMore, setIncludeIsSeeMore] = useState<boolean>(false);
-  const [includeIsBound, setIncludeIsBound] = useState<boolean>(false);
+  const [includeSeeMore, setIncludeSeeMore] = useState<boolean>(false);
+  const [includeBound, setIncludeBound] = useState<boolean>(false);
   const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map((item) => item.id));
   const [shouldMergeGate, setShouldMergeGate] = useState<boolean>(true);
 
@@ -51,15 +51,15 @@ export const ContentWageListPageProvider = ({ children }: PropsWithChildren) => 
     <ContentWageListPageContext.Provider
       value={{
         contentCategoryId,
-        includeIsBound,
-        includeIsSeeMore,
+        includeBound,
         includeItemIds,
+        includeSeeMore,
         items,
         keyword,
         setContentCategoryId,
-        setIncludeIsBound,
-        setIncludeIsSeeMore,
+        setIncludeBound,
         setIncludeItemIds,
+        setIncludeSeeMore,
         setKeyword,
         setShouldMergeGate,
         shouldMergeGate,

--- a/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.graphql
+++ b/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.graphql
@@ -8,7 +8,7 @@ query UserExtraItemPriceEditDialog($id: Int!) {
   }
 }
 
-mutation UserItemPriceEdit($input: UserItemPriceEditInput!) {
+mutation UserItemPriceEdit($input: EditUserItemPriceInput!) {
   userItemPriceEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.tsx
+++ b/src/frontend/src/pages/item-price-list/tabs/extra-item-tab/components/user-extra-item-price-edit-dialog.tsx
@@ -4,7 +4,7 @@ import { Form, z } from "~/core/form";
 import {
   UserExtraItemPriceEditDialogDocument,
   UserItemPriceEditDocument,
-  UserItemPriceEditInput,
+  EditUserItemPriceInput,
   UserItemPriceEditMutation,
   UserExtraItemPriceEditDialogQuery,
   UserExtraItemPriceEditDialogQueryVariables,
@@ -27,7 +27,7 @@ export const UserExtraItemPriceEditDialog = ({
 }: UserExtraItemPriceEditDialogProps & DialogProps) => {
   return (
     <Dialog<
-      UserItemPriceEditInput,
+      EditUserItemPriceInput,
       UserItemPriceEditMutation,
       UserExtraItemPriceEditDialogQuery,
       UserExtraItemPriceEditDialogQueryVariables

--- a/src/frontend/src/shared/content/content-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-details-dialog.tsx
@@ -174,8 +174,8 @@ const ContentWageSection = ({
   contentId: number;
   items: { id: number; name: string }[];
 }) => {
-  const [includeIsSeeMore, setIncludeIsSeeMore] = useState(false);
-  const [includeIsBound, setIncludeIsBound] = useState(false);
+  const [includeSeeMore, setIncludeSeeMore] = useState(false);
+  const [includeBound, setIncludeBound] = useState(false);
   const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map(({ id }) => id));
 
   return (
@@ -203,14 +203,14 @@ const ContentWageSection = ({
                   </Field>
                   <Field label="더보기 포함 여부" w="auto">
                     <ContentSeeMoreFilter
-                      includeIsSeeMore={includeIsSeeMore}
-                      setIncludeIsSeeMore={setIncludeIsSeeMore}
+                      includeSeeMore={includeSeeMore}
+                      setIncludeSeeMore={setIncludeSeeMore}
                     />
                   </Field>
                   <Field label="귀속 재료 포함 여부" w="auto">
                     <ContentIsBoundFilter
-                      includeIsBound={includeIsBound}
-                      setIncludeIsBound={setIncludeIsBound}
+                      includeBound={includeBound}
+                      setIncludeBound={setIncludeBound}
                     />
                   </Field>
                 </Flex>
@@ -223,9 +223,9 @@ const ContentWageSection = ({
       <Suspense fallback={<TableSkeleton line={1} />}>
         <ContentWageSectionDataGrid
           contentId={contentId}
-          includeIsBound={includeIsBound}
-          includeIsSeeMore={includeIsSeeMore}
+          includeBound={includeBound}
           includeItemIds={includeItemIds}
+          includeSeeMore={includeSeeMore}
         />
       </Suspense>
     </Section>
@@ -234,23 +234,23 @@ const ContentWageSection = ({
 
 const ContentWageSectionDataGrid = ({
   contentId,
-  includeIsBound,
-  includeIsSeeMore,
+  includeBound,
   includeItemIds,
+  includeSeeMore,
 }: {
   contentId: number;
-  includeIsBound: boolean;
-  includeIsSeeMore: boolean;
+  includeBound: boolean;
   includeItemIds: number[];
+  includeSeeMore: boolean;
 }) => {
   const { isAuthenticated } = useAuth();
   const { data, refetch } = useSafeQuery(ContentDetailsDialogWageSectionDocument, {
     variables: {
       contentId,
       filter: {
-        includeIsBound,
-        includeIsSeeMore,
+        includeBound,
         includeItemIds,
+        includeSeeMore,
       },
     },
   });
@@ -294,11 +294,11 @@ const ContentWageSectionDataGrid = ({
 };
 
 const ContentSeeMoreFilter = ({
-  includeIsSeeMore,
-  setIncludeIsSeeMore,
+  includeSeeMore,
+  setIncludeSeeMore,
 }: {
-  includeIsSeeMore: boolean;
-  setIncludeIsSeeMore: (value: boolean) => void;
+  includeSeeMore: boolean;
+  setIncludeSeeMore: (value: boolean) => void;
 }) => {
   return (
     <SegmentedControl
@@ -306,18 +306,18 @@ const ContentSeeMoreFilter = ({
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsSeeMore(e.value === "true")}
-      value={includeIsSeeMore ? "true" : "false"}
+      onValueChange={(e) => setIncludeSeeMore(e.value === "true")}
+      value={includeSeeMore ? "true" : "false"}
     />
   );
 };
 
 const ContentIsBoundFilter = ({
-  includeIsBound,
-  setIncludeIsBound,
+  includeBound,
+  setIncludeBound,
 }: {
-  includeIsBound: boolean;
-  setIncludeIsBound: (value: boolean) => void;
+  includeBound: boolean;
+  setIncludeBound: (value: boolean) => void;
 }) => {
   return (
     <SegmentedControl
@@ -325,8 +325,8 @@ const ContentIsBoundFilter = ({
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsBound(e.value === "true")}
-      value={includeIsBound ? "true" : "false"}
+      onValueChange={(e) => setIncludeBound(e.value === "true")}
+      value={includeBound ? "true" : "false"}
     />
   );
 };

--- a/src/frontend/src/shared/content/content-duration-edit-dialog.graphql
+++ b/src/frontend/src/shared/content/content-duration-edit-dialog.graphql
@@ -5,7 +5,7 @@ query ContentDurationEditDialog($id: Int!) {
   }
 }
 
-mutation ContentDurationEdit($input: ContentDurationEditInput!) {
+mutation ContentDurationEdit($input: EditContentDurationInput!) {
   contentDurationEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/shared/content/content-duration-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-duration-edit-dialog.tsx
@@ -6,7 +6,7 @@ import { Form, z } from "~/core/form";
 import {
   ContentDurationEditDialogDocument,
   ContentDurationEditDocument,
-  ContentDurationEditInput,
+  EditContentDurationInput,
   ContentDurationEditMutation,
   ContentDurationEditDialogQuery,
   ContentDurationEditDialogQueryVariables,
@@ -30,7 +30,7 @@ export const ContentDurationEditDialog = ({
 }: ContentDurationEditDialogProps & DialogProps) => {
   return (
     <Dialog<
-      ContentDurationEditInput,
+      EditContentDurationInput,
       ContentDurationEditMutation,
       ContentDurationEditDialogQuery,
       ContentDurationEditDialogQueryVariables

--- a/src/frontend/src/shared/content/content-group-details-dialog.tsx
+++ b/src/frontend/src/shared/content/content-group-details-dialog.tsx
@@ -200,8 +200,8 @@ const ContentWageSection = ({
   contentId: number;
   items: { id: number; name: string }[];
 }) => {
-  const [includeIsSeeMore, setIncludeIsSeeMore] = useState(false);
-  const [includeIsBound, setIncludeIsBound] = useState(false);
+  const [includeSeeMore, setIncludeSeeMore] = useState(false);
+  const [includeBound, setIncludeBound] = useState(false);
   const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map(({ id }) => id));
 
   return (
@@ -229,14 +229,14 @@ const ContentWageSection = ({
                   </Field>
                   <Field label="더보기 포함 여부" w="auto">
                     <ContentSeeMoreFilter
-                      includeIsSeeMore={includeIsSeeMore}
-                      setIncludeIsSeeMore={setIncludeIsSeeMore}
+                      includeSeeMore={includeSeeMore}
+                      setIncludeSeeMore={setIncludeSeeMore}
                     />
                   </Field>
                   <Field label="귀속 재료 포함 여부" w="auto">
                     <ContentIsBoundFilter
-                      includeIsBound={includeIsBound}
-                      setIncludeIsBound={setIncludeIsBound}
+                      includeBound={includeBound}
+                      setIncludeBound={setIncludeBound}
                     />
                   </Field>
                 </Flex>
@@ -249,9 +249,9 @@ const ContentWageSection = ({
       <Suspense fallback={<TableSkeleton line={1} />}>
         <ContentWageSectionDataGrid
           contentId={contentId}
-          includeIsBound={includeIsBound}
-          includeIsSeeMore={includeIsSeeMore}
+          includeBound={includeBound}
           includeItemIds={includeItemIds}
+          includeSeeMore={includeSeeMore}
         />
       </Suspense>
     </Section>
@@ -260,23 +260,23 @@ const ContentWageSection = ({
 
 const ContentWageSectionDataGrid = ({
   contentId,
-  includeIsBound,
-  includeIsSeeMore,
+  includeBound,
   includeItemIds,
+  includeSeeMore,
 }: {
   contentId: number;
-  includeIsBound: boolean;
-  includeIsSeeMore: boolean;
+  includeBound: boolean;
   includeItemIds: number[];
+  includeSeeMore: boolean;
 }) => {
   const { isAuthenticated } = useAuth();
   const { data, refetch } = useSafeQuery(ContentDetailsDialogWageSectionDocument, {
     variables: {
       contentId,
       filter: {
-        includeIsBound,
-        includeIsSeeMore,
+        includeBound,
         includeItemIds,
+        includeSeeMore,
       },
     },
   });
@@ -320,11 +320,11 @@ const ContentWageSectionDataGrid = ({
 };
 
 const ContentSeeMoreFilter = ({
-  includeIsSeeMore,
-  setIncludeIsSeeMore,
+  includeSeeMore,
+  setIncludeSeeMore,
 }: {
-  includeIsSeeMore: boolean;
-  setIncludeIsSeeMore: (value: boolean) => void;
+  includeSeeMore: boolean;
+  setIncludeSeeMore: (value: boolean) => void;
 }) => {
   return (
     <SegmentedControl
@@ -332,18 +332,18 @@ const ContentSeeMoreFilter = ({
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsSeeMore(e.value === "true")}
-      value={includeIsSeeMore ? "true" : "false"}
+      onValueChange={(e) => setIncludeSeeMore(e.value === "true")}
+      value={includeSeeMore ? "true" : "false"}
     />
   );
 };
 
 const ContentIsBoundFilter = ({
-  includeIsBound,
-  setIncludeIsBound,
+  includeBound,
+  setIncludeBound,
 }: {
-  includeIsBound: boolean;
-  setIncludeIsBound: (value: boolean) => void;
+  includeBound: boolean;
+  setIncludeBound: (value: boolean) => void;
 }) => {
   return (
     <SegmentedControl
@@ -351,8 +351,8 @@ const ContentIsBoundFilter = ({
         { label: "미포함", value: "false" },
         { label: "포함", value: "true" },
       ]}
-      onValueChange={(e) => setIncludeIsBound(e.value === "true")}
-      value={includeIsBound ? "true" : "false"}
+      onValueChange={(e) => setIncludeBound(e.value === "true")}
+      value={includeBound ? "true" : "false"}
     />
   );
 };

--- a/src/frontend/src/shared/content/content-group-duration-edit-dialog.graphql
+++ b/src/frontend/src/shared/content/content-group-duration-edit-dialog.graphql
@@ -9,7 +9,7 @@ query ContentGroupDurationEditDialog($ids: [Int!]!) {
   }
 }
 
-mutation ContentDurationsEdit($input: ContentDurationsEditInput!) {
+mutation ContentDurationsEdit($input: EditContentDurationsInput!) {
   contentDurationsEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/shared/content/content-group-duration-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-group-duration-edit-dialog.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogProps } from "~/core/dialog";
 import { Form, z } from "~/core/form";
 import {
   ContentDurationsEditDocument,
-  ContentDurationsEditInput,
+  EditContentDurationsInput,
   ContentDurationsEditMutation,
   ContentGroupDurationEditDialogDocument,
   ContentGroupDurationEditDialogQuery,
@@ -34,7 +34,7 @@ export const ContentGroupDurationEditDialog = ({
 }: ContentGroupDurationEditDialogProps & DialogProps) => {
   return (
     <Dialog<
-      ContentDurationsEditInput,
+      EditContentDurationsInput,
       ContentDurationsEditMutation,
       ContentGroupDurationEditDialogQuery,
       ContentGroupDurationEditDialogQueryVariables

--- a/src/frontend/src/shared/content/content-reward-edit-dialog.graphql
+++ b/src/frontend/src/shared/content/content-reward-edit-dialog.graphql
@@ -13,7 +13,7 @@ query ContentRewardEditDialog($id: Int!) {
   }
 }
 
-mutation ContentRewardsEdit($input: ContentRewardsEditInput!) {
+mutation ContentRewardsEdit($input: EditContentRewardsInput!) {
   contentRewardsEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/shared/content/content-reward-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-reward-edit-dialog.tsx
@@ -9,7 +9,7 @@ import {
   ContentRewardEditDialogQuery,
   ContentRewardEditDialogQueryVariables,
   ContentRewardsEditDocument,
-  ContentRewardsEditInput,
+  EditContentRewardsInput,
   ContentRewardsEditMutation,
 } from "~/core/graphql/generated";
 
@@ -39,7 +39,7 @@ export const ContentRewardEditDialog = ({
 }: ContentRewardEditDialogProps & DialogProps) => {
   return (
     <Dialog<
-      ContentRewardsEditInput,
+      EditContentRewardsInput,
       ContentRewardsEditMutation,
       ContentRewardEditDialogQuery,
       ContentRewardEditDialogQueryVariables

--- a/src/frontend/src/shared/content/content-reward-report-dialog.graphql
+++ b/src/frontend/src/shared/content/content-reward-report-dialog.graphql
@@ -11,7 +11,7 @@ query ContentRewardReportDialog($id: Int!) {
   }
 }
 
-mutation ContentRewardsReport($input: ContentRewardsReportInput!) {
+mutation ContentRewardsReport($input: ReportContentRewardsInput!) {
   contentRewardsReport(input: $input) {
     ok
   }

--- a/src/frontend/src/shared/content/content-reward-report-dialog.tsx
+++ b/src/frontend/src/shared/content/content-reward-report-dialog.tsx
@@ -4,7 +4,7 @@ import { Form, z } from "~/core/form";
 import {
   ContentRewardReportDialogDocument,
   ContentRewardsReportDocument,
-  ContentRewardsReportInput,
+  ReportContentRewardsInput,
   ContentRewardsReportMutation,
   ContentRewardReportDialogQuery,
   ContentRewardReportDialogQueryVariables,
@@ -29,7 +29,7 @@ export const ContentRewardReportDialog = ({
 }: ContentRewardReportDialogProps & DialogProps) => {
   return (
     <Dialog<
-      ContentRewardsReportInput,
+      ReportContentRewardsInput,
       ContentRewardsReportMutation,
       ContentRewardReportDialogQuery,
       ContentRewardReportDialogQueryVariables

--- a/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.graphql
+++ b/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.graphql
@@ -12,7 +12,7 @@ query ContentSeeMoreRewardEditDialog($id: Int!) {
   }
 }
 
-mutation ContentSeeMoreRewardsEdit($input: ContentSeeMoreRewardsEditInput!) {
+mutation ContentSeeMoreRewardsEdit($input: EditContentSeeMoreRewardsInput!) {
   contentSeeMoreRewardsEdit(input: $input) {
     ok
   }

--- a/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.tsx
+++ b/src/frontend/src/shared/content/content-see-more-reward-edit-dialog.tsx
@@ -4,7 +4,7 @@ import { Form, z } from "~/core/form";
 import {
   ContentSeeMoreRewardEditDialogDocument,
   ContentSeeMoreRewardsEditDocument,
-  ContentSeeMoreRewardsEditInput,
+  EditContentSeeMoreRewardsInput,
   ContentSeeMoreRewardsEditMutation,
   ContentSeeMoreRewardEditDialogQuery,
   ContentSeeMoreRewardEditDialogQueryVariables,
@@ -32,7 +32,7 @@ export const ContentSeeMoreRewardEditDialog = ({
 }: ContentSeeMoreRewardEditDialogProps & DialogProps) => {
   return (
     <Dialog<
-      ContentSeeMoreRewardsEditInput,
+      EditContentSeeMoreRewardsInput,
       ContentSeeMoreRewardsEditMutation,
       ContentSeeMoreRewardEditDialogQuery,
       ContentSeeMoreRewardEditDialogQueryVariables


### PR DESCRIPTION
- InputType 클래스명을 Action-First 패턴으로 변경 (예: ContentCreateInput → CreateContentInput)
- Boolean 필드에서 이중 "is" 접두사 제거 (includeIsBound → includeBound, includeIsSeeMore → includeSeeMore)
- 모든 nullable 필드에 설명 추가

fix #225