### PR TITLE
feat(backend): GraphQL InputType 자동 검증 인프라 구축

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -34,6 +34,8 @@
     "@prisma/client": "5.22.0",
     "@quixo3/prisma-session-store": "3.1.13",
     "apollo-server-express": "3.13.0",
+    "class-transformer": "0.5.1",
+    "class-validator": "0.14.2",
     "dataloader": "2.2.3",
     "dayjs": "1.11.13",
     "discord-webhook-node": "1.1.8",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -12,28 +12,28 @@ importers:
         version: 4.11.2(graphql@16.9.0)
       "@nestjs/apollo":
         specifier: 12.2.1
-        version: 12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(graphql@16.9.0)(reflect-metadata@0.2.0))(graphql@16.9.0)
+        version: 12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.2)(graphql@16.9.0)(reflect-metadata@0.2.0))(graphql@16.9.0)
       "@nestjs/common":
         specifier: 10.4.16
-        version: 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+        version: 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       "@nestjs/config":
         specifier: 3.3.0
-        version: 3.3.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(rxjs@7.8.1)
+        version: 3.3.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(rxjs@7.8.1)
       "@nestjs/core":
         specifier: 10.0.0
-        version: 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+        version: 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       "@nestjs/graphql":
         specifier: 12.2.1
-        version: 12.2.1(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(graphql@16.9.0)(reflect-metadata@0.2.0)
+        version: 12.2.1(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.2)(graphql@16.9.0)(reflect-metadata@0.2.0)
       "@nestjs/passport":
         specifier: 10.0.3
-        version: 10.0.3(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(passport@0.7.0)
+        version: 10.0.3(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(passport@0.7.0)
       "@nestjs/platform-express":
         specifier: 10.0.0
-        version: 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
+        version: 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
       "@nestjs/serve-static":
         specifier: 4.0.2
-        version: 4.0.2(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(express@4.21.2)
+        version: 4.0.2(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(express@4.21.2)
       "@prisma/client":
         specifier: 5.22.0
         version: 5.22.0(prisma@6.4.1(typescript@5.1.3))
@@ -43,6 +43,12 @@ importers:
       apollo-server-express:
         specifier: 3.13.0
         version: 3.13.0(express@4.21.2)(graphql@16.9.0)
+      class-transformer:
+        specifier: 0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: 0.14.2
+        version: 0.14.2
       dataloader:
         specifier: 2.2.3
         version: 2.2.3
@@ -63,7 +69,7 @@ importers:
         version: 4.17.21
       nestjs-cls:
         specifier: 6.1.0
-        version: 6.1.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+        version: 6.1.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       passport:
         specifier: 0.7.0
         version: 0.7.0
@@ -103,7 +109,7 @@ importers:
         version: 10.0.0(chokidar@3.5.3)(typescript@5.1.3)
       "@nestjs/testing":
         specifier: 10.0.0
-        version: 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)
+        version: 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)
       "@types/express":
         specifier: 5.0.0
         version: 5.0.0
@@ -148,7 +154,7 @@ importers:
         version: 29.5.0(@types/node@20.3.1)(ts-node@10.9.1(@types/node@20.3.1)(typescript@5.1.3))
       nestjs-console:
         specifier: 9.0.0
-        version: 9.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
+        version: 9.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
@@ -2021,6 +2027,12 @@ packages:
         integrity: sha512-j3/Z2avY+H3yn+xp/ef//QyqqE+dg3rWh14Ewi/QZs6uVK+oOs7lFRXtjp2YHAqHJZ4OFGNmCxZO5vd7AuG/Dg==,
       }
 
+  "@types/validator@13.15.10":
+    resolution:
+      {
+        integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==,
+      }
+
   "@types/yargs-parser@21.0.3":
     resolution:
       {
@@ -2821,6 +2833,18 @@ packages:
     resolution:
       {
         integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==,
+      }
+
+  class-transformer@0.5.1:
+    resolution:
+      {
+        integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==,
+      }
+
+  class-validator@0.14.2:
+    resolution:
+      {
+        integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==,
       }
 
   cli-cursor@3.1.0:
@@ -4517,6 +4541,12 @@ packages:
         integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
       }
     engines: { node: ">= 0.8.0" }
+
+  libphonenumber-js@1.12.29:
+    resolution:
+      {
+        integrity: sha512-P2aLrbeqHbmh8+9P35LXQfXOKc7XJ0ymUKl7tyeyQjdRNfzunXWxQXGc4yl3fUf28fqLRfPY+vIVvFXK7KEBTw==,
+      }
 
   lines-and-columns@1.2.4:
     resolution:
@@ -6226,6 +6256,13 @@ packages:
       }
     engines: { node: ">=10.12.0" }
 
+  validator@13.15.23:
+    resolution:
+      {
+        integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==,
+      }
+    engines: { node: ">= 0.10" }
+
   value-or-promise@1.0.11:
     resolution:
       {
@@ -7285,13 +7322,13 @@ snapshots:
 
   "@lukeed/csprng@1.1.0": {}
 
-  "@nestjs/apollo@12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(graphql@16.9.0)(reflect-metadata@0.2.0))(graphql@16.9.0)":
+  "@nestjs/apollo@12.2.1(@apollo/server@4.11.2(graphql@16.9.0))(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.2)(graphql@16.9.0)(reflect-metadata@0.2.0))(graphql@16.9.0)":
     dependencies:
       "@apollo/server": 4.11.2(graphql@16.9.0)
       "@apollo/server-plugin-landing-page-graphql-playground": 4.0.0(@apollo/server@4.11.2(graphql@16.9.0))
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/graphql": 12.2.1(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(graphql@16.9.0)(reflect-metadata@0.2.0)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/graphql": 12.2.1(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.2)(graphql@16.9.0)(reflect-metadata@0.2.0)
       graphql: 16.9.0
       iterall: 1.3.0
       lodash.omit: 4.5.0
@@ -7326,25 +7363,28 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)":
+  "@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)":
     dependencies:
       iterare: 1.2.1
       reflect-metadata: 0.2.0
       rxjs: 7.8.1
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
-  "@nestjs/config@3.3.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(rxjs@7.8.1)":
+  "@nestjs/config@3.3.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(rxjs@7.8.1)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
       lodash: 4.17.21
       rxjs: 7.8.1
 
-  "@nestjs/core@10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)":
+  "@nestjs/core@10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       "@nuxtjs/opencollective": 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -7354,18 +7394,18 @@ snapshots:
       tslib: 2.5.3
       uid: 2.0.2
     optionalDependencies:
-      "@nestjs/platform-express": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
+      "@nestjs/platform-express": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
     transitivePeerDependencies:
       - encoding
 
-  "@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(graphql@16.9.0)(reflect-metadata@0.2.0)":
+  "@nestjs/graphql@12.2.1(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.2)(graphql@16.9.0)(reflect-metadata@0.2.0)":
     dependencies:
       "@graphql-tools/merge": 9.0.8(graphql@16.9.0)
       "@graphql-tools/schema": 10.0.7(graphql@16.9.0)
       "@graphql-tools/utils": 10.5.5(graphql@16.9.0)
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/mapped-types": 2.0.5(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(reflect-metadata@0.2.0)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/mapped-types": 2.0.5(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)
       chokidar: 4.0.1
       fast-glob: 3.3.2
       graphql: 16.9.0
@@ -7378,24 +7418,30 @@ snapshots:
       tslib: 2.8.0
       uuid: 10.0.0
       ws: 8.18.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  "@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(reflect-metadata@0.2.0)":
+  "@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       reflect-metadata: 0.2.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
-  "@nestjs/passport@10.0.3(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(passport@0.7.0)":
+  "@nestjs/passport@10.0.3(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(passport@0.7.0)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       passport: 0.7.0
 
-  "@nestjs/platform-express@10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)":
+  "@nestjs/platform-express@10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       body-parser: 1.20.2
       cors: 2.8.5
       express: 4.18.2
@@ -7415,21 +7461,21 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  "@nestjs/serve-static@4.0.2(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(express@4.21.2)":
+  "@nestjs/serve-static@4.0.2(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(express@4.21.2)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       path-to-regexp: 0.2.5
     optionalDependencies:
       express: 4.21.2
 
-  "@nestjs/testing@10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)":
+  "@nestjs/testing@10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)":
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       tslib: 2.5.3
     optionalDependencies:
-      "@nestjs/platform-express": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
+      "@nestjs/platform-express": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)
 
   "@noble/hashes@1.8.0": {}
 
@@ -7744,6 +7790,8 @@ snapshots:
       "@types/cookiejar": 2.1.5
       "@types/methods": 1.1.4
       "@types/superagent": 8.1.9
+
+  "@types/validator@13.15.10": {}
 
   "@types/yargs-parser@21.0.3": {}
 
@@ -8387,6 +8435,14 @@ snapshots:
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.14.2:
+    dependencies:
+      "@types/validator": 13.15.10
+      libphonenumber-js: 1.12.29
+      validator: 13.15.23
 
   cli-cursor@3.1.0:
     dependencies:
@@ -9657,6 +9713,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  libphonenumber-js@1.12.29: {}
+
   lines-and-columns@1.2.4: {}
 
   loader-runner@4.3.1: {}
@@ -9801,17 +9859,17 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestjs-cls@6.1.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1):
+  nestjs-cls@6.1.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1):
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       reflect-metadata: 0.2.0
       rxjs: 7.8.1
 
-  nestjs-console@9.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0):
+  nestjs-console@9.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/core@10.0.0):
     dependencies:
-      "@nestjs/common": 10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1)
-      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/common": 10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1)
+      "@nestjs/core": 10.0.0(@nestjs/common@10.4.16(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.0)(rxjs@7.8.1))(@nestjs/platform-express@10.0.0)(reflect-metadata@0.2.0)(rxjs@7.8.1)
       commander: 11.1.0
 
   node-abort-controller@3.1.1: {}
@@ -10591,6 +10649,8 @@ snapshots:
       "@jridgewell/trace-mapping": 0.3.31
       "@types/istanbul-lib-coverage": 2.0.6
       convert-source-map: 2.0.0
+
+  validator@13.15.23: {}
 
   value-or-promise@1.0.11: {}
 

--- a/src/backend/src/common/constants/content.constants.ts
+++ b/src/backend/src/common/constants/content.constants.ts
@@ -1,0 +1,2 @@
+export const CONTENT_LEVEL_MAX = 1700;
+export const CONTENT_NAME_MAX_LENGTH = 100;

--- a/src/backend/src/common/constants/item.constants.ts
+++ b/src/backend/src/common/constants/item.constants.ts
@@ -1,0 +1,3 @@
+export const ITEM_CATEGORY_NAME_MAX_LENGTH = 100;
+export const ITEM_GRADE_MAX_LENGTH = 50;
+export const ITEM_KEYWORD_MAX_LENGTH = 100;

--- a/src/backend/src/common/pipes/validation.pipe.e2e-spec.ts
+++ b/src/backend/src/common/pipes/validation.pipe.e2e-spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { GraphQLModule } from "@nestjs/graphql";
+import { ApolloDriver, ApolloDriverConfig } from "@nestjs/apollo";
+import { Query, Resolver } from "@nestjs/graphql";
+
+@Resolver()
+class DummyResolver {
+  @Query(() => String)
+  dummyQuery(): string {
+    return "dummy";
+  }
+}
+
+describe("ValidationPipe Integration (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot<ApolloDriverConfig>({
+          autoSchemaFile: true,
+          driver: ApolloDriver,
+        }),
+      ],
+      providers: [DummyResolver],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    // Apply same ValidationPipe config as main.ts
+    app.useGlobalPipes(
+      new ValidationPipe({
+        skipNullProperties: true,
+        skipUndefinedProperties: true,
+        transform: true,
+        transformOptions: {
+          enableImplicitConversion: true,
+        },
+        whitelist: false,
+      })
+    );
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("ValidationPipe가 GraphQL에서 작동하는지 확인", () => {
+    // This test verifies that ValidationPipe is properly configured
+    // and integrated with the GraphQL module
+    expect(app).toBeDefined();
+  });
+
+  // Note: Full integration tests would require setting up actual resolvers
+  // and database connections. Those are covered in resolver e2e tests.
+});

--- a/src/backend/src/content/content/content.dto.spec.ts
+++ b/src/backend/src/content/content/content.dto.spec.ts
@@ -1,0 +1,249 @@
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { ContentListFilter, CreateContentInput, CreateContentItemInput } from "./content.dto";
+import { ContentStatus } from "@prisma/client";
+
+describe("ContentListFilter Validation", () => {
+  it("유효한 필터 입력을 허용해야 함", async () => {
+    const filter = plainToInstance(ContentListFilter, {
+      contentCategoryId: 1,
+      includeSeeMore: true,
+      keyword: "test",
+      status: ContentStatus.ACTIVE,
+    });
+
+    const errors = await validate(filter);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("모든 필드가 없어도 허용해야 함 (optional)", async () => {
+    const filter = plainToInstance(ContentListFilter, {});
+
+    const errors = await validate(filter);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("contentCategoryId가 0이어도 허용해야 함", async () => {
+    const filter = plainToInstance(ContentListFilter, {
+      contentCategoryId: 0,
+    });
+
+    const errors = await validate(filter);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("빈 keyword를 허용해야 함", async () => {
+    const filter = plainToInstance(ContentListFilter, {
+      keyword: "",
+    });
+
+    const errors = await validate(filter);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("keyword가 100자를 초과하면 에러", async () => {
+    const filter = plainToInstance(ContentListFilter, {
+      keyword: "a".repeat(101),
+    });
+
+    const errors = await validate(filter);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("keyword");
+  });
+
+  it("잘못된 status enum을 거부해야 함", async () => {
+    const filter = plainToInstance(ContentListFilter, {
+      status: "INVALID_STATUS",
+    });
+
+    const errors = await validate(filter);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("status");
+  });
+});
+
+describe("CreateContentInput Validation", () => {
+  const validInput = {
+    categoryId: 1,
+    contentRewards: [
+      {
+        averageQuantity: 10.5,
+        isBound: false,
+        itemId: 1,
+      },
+    ],
+    duration: 300,
+    level: 1600,
+    name: "Test Content",
+  };
+
+  it("유효한 입력을 허용해야 함", async () => {
+    const input = plainToInstance(CreateContentInput, validInput);
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("categoryId가 0 이하면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      categoryId: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("categoryId");
+  });
+
+  it("level이 1 미만이면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      level: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("level");
+  });
+
+  it("level이 1700 초과면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      level: 1701,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("level");
+  });
+
+  it("level 1과 1700은 유효함 (경계값)", async () => {
+    const input1 = plainToInstance(CreateContentInput, {
+      ...validInput,
+      level: 1,
+    });
+    const input2 = plainToInstance(CreateContentInput, {
+      ...validInput,
+      level: 1700,
+    });
+
+    const errors1 = await validate(input1);
+    const errors2 = await validate(input2);
+
+    expect(errors1).toHaveLength(0);
+    expect(errors2).toHaveLength(0);
+  });
+
+  it("duration이 0 이하면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      duration: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("duration");
+  });
+
+  it("name이 비어있으면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      name: "",
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("name");
+  });
+
+  it("name이 100자를 초과하면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      name: "a".repeat(101),
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("name");
+  });
+
+  it("contentRewards가 빈 배열이면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      contentRewards: [],
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("contentRewards");
+  });
+
+  it("gate가 0 이하면 에러", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      gate: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("gate");
+  });
+
+  it("gate가 null이면 허용", async () => {
+    const input = plainToInstance(CreateContentInput, {
+      ...validInput,
+      gate: null,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("CreateContentItemInput Validation", () => {
+  it("유효한 입력을 허용해야 함", async () => {
+    const input = plainToInstance(CreateContentItemInput, {
+      averageQuantity: 10.5,
+      isBound: false,
+      itemId: 1,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("averageQuantity가 음수면 에러", async () => {
+    const input = plainToInstance(CreateContentItemInput, {
+      averageQuantity: -1,
+      isBound: false,
+      itemId: 1,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("averageQuantity");
+  });
+
+  it("averageQuantity가 0이면 허용", async () => {
+    const input = plainToInstance(CreateContentItemInput, {
+      averageQuantity: 0,
+      isBound: false,
+      itemId: 1,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("itemId가 0 이하면 에러", async () => {
+    const input = plainToInstance(CreateContentItemInput, {
+      averageQuantity: 10,
+      isBound: false,
+      itemId: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("itemId");
+  });
+});

--- a/src/backend/src/content/content/content.dto.ts
+++ b/src/backend/src/content/content/content.dto.ts
@@ -1,5 +1,21 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from "class-validator";
 import { ContentStatus } from "@prisma/client";
+import { Type } from "class-transformer";
+import { CONTENT_LEVEL_MAX, CONTENT_NAME_MAX_LENGTH } from "src/common/constants/content.constants";
 
 @InputType()
 export class ContentListFilter {
@@ -7,24 +23,33 @@ export class ContentListFilter {
     description: "필터링할 컨텐츠 카테고리 ID",
     nullable: true,
   })
+  @IsOptional()
+  @IsNumber()
   contentCategoryId?: number;
 
   @Field(() => Boolean, {
     description: "추가 보상(더보기) 포함 여부",
     nullable: true,
   })
+  @IsOptional()
+  @IsBoolean()
   includeSeeMore?: boolean;
 
   @Field(() => String, {
     description: "검색 키워드",
     nullable: true,
   })
+  @IsOptional()
+  @IsString()
+  @MaxLength(CONTENT_NAME_MAX_LENGTH)
   keyword?: string;
 
   @Field(() => ContentStatus, {
     description: "컨텐츠 상태",
     nullable: true,
   })
+  @IsOptional()
+  @IsEnum(ContentStatus)
   status?: ContentStatus;
 }
 
@@ -34,56 +59,90 @@ export class ContentsFilter {
     description: "필터링할 컨텐츠 ID 목록",
     nullable: true,
   })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
   ids?: number[];
 }
 
 @InputType()
 export class CreateContentInput {
   @Field({ description: "컨텐츠 카테고리 ID" })
+  @IsNumber()
+  @Min(1)
   categoryId: number;
 
   @Field(() => [CreateContentItemInput], {
     description: "컨텐츠 보상 아이템 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateContentItemInput)
   contentRewards: CreateContentItemInput[];
 
   @Field(() => [CreateContentSeeMoreRewardInput], {
     description: "추가 보상(더보기) 아이템 목록",
     nullable: true,
   })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateContentSeeMoreRewardInput)
   contentSeeMoreRewards?: CreateContentSeeMoreRewardInput[];
 
   @Field({ description: "소요 시간 (초)" })
+  @IsNumber()
+  @Min(1)
   duration: number;
 
   @Field({ description: "관문 번호", nullable: true })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
   gate?: number | null;
 
   @Field({ description: "레벨" })
+  @IsNumber()
+  @Min(1)
+  @Max(CONTENT_LEVEL_MAX)
   level: number;
 
   @Field({ description: "컨텐츠 이름" })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(CONTENT_NAME_MAX_LENGTH)
   name: string;
 }
 
 @InputType()
 export class CreateContentItemInput {
   @Field(() => Float, { description: "평균 획득 수량" })
+  @IsNumber()
+  @Min(0)
   averageQuantity: number;
 
   @Field({ description: "귀속 여부" })
+  @IsBoolean()
   isBound: boolean;
 
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   itemId: number;
 }
 
 @InputType()
 export class CreateContentSeeMoreRewardInput {
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   itemId: number;
 
   @Field(() => Float, { description: "획득 수량" })
+  @IsNumber()
+  @Min(0)
   quantity: number;
 }
 

--- a/src/backend/src/content/duration/duration.dto.spec.ts
+++ b/src/backend/src/content/duration/duration.dto.spec.ts
@@ -1,0 +1,83 @@
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { EditContentDurationInput } from "./duration.dto";
+
+describe("EditContentDurationInput Validation", () => {
+  it("유효한 시간 형식을 허용해야 함", async () => {
+    const input = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: 5,
+      seconds: 30,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("minutes가 59를 초과하면 에러", async () => {
+    const input = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: 60,
+      seconds: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("minutes");
+  });
+
+  it("seconds가 59를 초과하면 에러", async () => {
+    const input = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: 0,
+      seconds: 60,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("seconds");
+  });
+
+  it("minutes와 seconds가 0-59 범위면 허용 (경계값)", async () => {
+    const input1 = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: 0,
+      seconds: 0,
+    });
+    const input2 = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: 59,
+      seconds: 59,
+    });
+
+    const errors1 = await validate(input1);
+    const errors2 = await validate(input2);
+
+    expect(errors1).toHaveLength(0);
+    expect(errors2).toHaveLength(0);
+  });
+
+  it("minutes가 음수면 에러", async () => {
+    const input = plainToInstance(EditContentDurationInput, {
+      contentId: 1,
+      minutes: -1,
+      seconds: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("minutes");
+  });
+
+  it("contentId가 0 이하면 에러", async () => {
+    const input = plainToInstance(EditContentDurationInput, {
+      contentId: 0,
+      minutes: 5,
+      seconds: 30,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("contentId");
+  });
+});

--- a/src/backend/src/content/duration/duration.dto.ts
+++ b/src/backend/src/content/duration/duration.dto.ts
@@ -1,14 +1,24 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
+import { ArrayMinSize, IsArray, IsNumber, Max, Min, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
 
 @InputType()
 export class EditContentDurationInput {
   @Field({ description: "컨텐츠 ID" })
+  @IsNumber()
+  @Min(1)
   contentId: number;
 
   @Field(() => Int, { description: "분" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   minutes: number;
 
   @Field(() => Int, { description: "초" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   seconds: number;
 }
 
@@ -21,12 +31,20 @@ export class EditContentDurationResult {
 @InputType()
 export class EditContentDurationsDurationInput {
   @Field({ description: "컨텐츠 ID" })
+  @IsNumber()
+  @Min(1)
   contentId: number;
 
   @Field(() => Int, { description: "분" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   minutes: number;
 
   @Field(() => Int, { description: "초" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   seconds: number;
 }
 
@@ -35,6 +53,10 @@ export class EditContentDurationsInput {
   @Field(() => [EditContentDurationsDurationInput], {
     description: "수정할 컨텐츠 소요 시간 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => EditContentDurationsDurationInput)
   contentDurations: EditContentDurationsDurationInput[];
 }
 

--- a/src/backend/src/content/group/group.dto.ts
+++ b/src/backend/src/content/group/group.dto.ts
@@ -1,6 +1,8 @@
 import { Field, InputType } from "@nestjs/graphql";
+import { IsArray, IsEnum, IsNumber, IsOptional, IsString, MaxLength, Min } from "class-validator";
 import { ContentStatus } from "@prisma/client";
 import { ContentWageFilter } from "../wage/wage.dto";
+import { CONTENT_NAME_MAX_LENGTH } from "../../common/constants/content.constants";
 
 @InputType()
 export class ContentGroupFilter {
@@ -8,6 +10,10 @@ export class ContentGroupFilter {
     description: "그룹화할 컨텐츠 ID 목록",
     nullable: true,
   })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
   contentIds?: number[];
 }
 
@@ -17,11 +23,18 @@ export class ContentGroupWageListFilter extends ContentWageFilter {
     description: "필터링할 컨텐츠 카테고리 ID",
     nullable: true,
   })
+  @IsOptional()
+  @IsNumber()
   contentCategoryId?: number;
 
   @Field(() => String, { description: "검색 키워드", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(CONTENT_NAME_MAX_LENGTH)
   keyword?: string;
 
   @Field(() => ContentStatus, { description: "컨텐츠 상태", nullable: true })
+  @IsOptional()
+  @IsEnum(ContentStatus)
   status?: ContentStatus;
 }

--- a/src/backend/src/content/item/item.dto.ts
+++ b/src/backend/src/content/item/item.dto.ts
@@ -1,21 +1,32 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+import { IsEnum, IsNumber, IsOptional, IsString, MaxLength, Min } from "class-validator";
 import { ItemKind } from "@prisma/client";
+import { ITEM_KEYWORD_MAX_LENGTH } from "src/common/constants/item.constants";
 
 @InputType()
 export class ItemsFilter {
   @Field({ description: "제외할 아이템 이름", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(ITEM_KEYWORD_MAX_LENGTH)
   excludeItemName?: string;
 
   @Field(() => ItemKind, { description: "아이템 종류", nullable: true })
+  @IsOptional()
+  @IsEnum(ItemKind)
   kind?: ItemKind;
 }
 
 @InputType()
 export class EditUserItemPriceInput {
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   id: number;
 
   @Field(() => Float, { description: "사용자 지정 가격" })
+  @IsNumber()
+  @Min(0)
   price: number;
 }
 

--- a/src/backend/src/content/reward/reward.dto.ts
+++ b/src/backend/src/content/reward/reward.dto.ts
@@ -1,17 +1,26 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+import { ArrayMinSize, IsArray, IsBoolean, IsNumber, Min, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
 
 @InputType()
 export class EditContentRewardInput {
   @Field(() => Float, { description: "평균 획득 수량" })
+  @IsNumber()
+  @Min(0)
   averageQuantity: number;
 
   @Field({ description: "컨텐츠 ID" })
+  @IsNumber()
+  @Min(1)
   contentId: number;
 
   @Field(() => Boolean, { description: "거래 가능 여부" })
+  @IsBoolean()
   isSellable: boolean;
 
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   itemId: number;
 }
 
@@ -20,9 +29,14 @@ export class EditContentRewardsInput {
   @Field(() => [EditContentRewardInput], {
     description: "수정할 컨텐츠 보상 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => EditContentRewardInput)
   contentRewards: EditContentRewardInput[];
 
   @Field({ description: "제보 가능 여부" })
+  @IsBoolean()
   isReportable: boolean;
 }
 
@@ -35,9 +49,13 @@ export class EditContentRewardsResult {
 @InputType()
 export class ReportContentRewardInput {
   @Field(() => Float, { description: "평균 획득 수량" })
+  @IsNumber()
+  @Min(0)
   averageQuantity: number;
 
   @Field({ description: "컨텐츠 보상 ID" })
+  @IsNumber()
+  @Min(1)
   id: number;
 }
 
@@ -46,6 +64,10 @@ export class ReportContentRewardsInput {
   @Field(() => [ReportContentRewardInput], {
     description: "제보할 컨텐츠 보상 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => ReportContentRewardInput)
   contentRewards: ReportContentRewardInput[];
 }
 

--- a/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
@@ -1,14 +1,22 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
+import { ArrayMinSize, IsArray, IsNumber, Min, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
 
 @InputType()
 export class EditContentSeeMoreRewardInput {
   @Field({ description: "컨텐츠 ID" })
+  @IsNumber()
+  @Min(1)
   contentId: number;
 
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   itemId: number;
 
   @Field(() => Float, { description: "획득 수량" })
+  @IsNumber()
+  @Min(0)
   quantity: number;
 }
 
@@ -17,6 +25,10 @@ export class EditContentSeeMoreRewardsInput {
   @Field(() => [EditContentSeeMoreRewardInput], {
     description: "수정할 추가 보상(더보기) 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => EditContentSeeMoreRewardInput)
   contentSeeMoreRewards: EditContentSeeMoreRewardInput[];
 }
 

--- a/src/backend/src/content/wage/wage.dto.spec.ts
+++ b/src/backend/src/content/wage/wage.dto.spec.ts
@@ -1,0 +1,86 @@
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { CalculateCustomContentWageInput } from "./wage.dto";
+
+describe("CalculateCustomContentWageInput Validation", () => {
+  const validInput = {
+    items: [
+      {
+        id: 1,
+        quantity: 10.5,
+      },
+    ],
+    minutes: 5,
+    seconds: 30,
+  };
+
+  it("유효한 입력을 허용해야 함", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, validInput);
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("minutes가 59를 초과하면 에러", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, {
+      ...validInput,
+      minutes: 60,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("minutes");
+  });
+
+  it("seconds가 59를 초과하면 에러", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, {
+      ...validInput,
+      seconds: 60,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("seconds");
+  });
+
+  it("items가 빈 배열이면 에러", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, {
+      ...validInput,
+      items: [],
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("items");
+  });
+
+  it("중첩된 item 검증이 작동해야 함 (itemId < 1)", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, {
+      ...validInput,
+      items: [
+        {
+          id: 0,
+          quantity: 10,
+        },
+      ],
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("중첩된 item 검증이 작동해야 함 (quantity < 0)", async () => {
+    const input = plainToInstance(CalculateCustomContentWageInput, {
+      ...validInput,
+      items: [
+        {
+          id: 1,
+          quantity: -1,
+        },
+      ],
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/backend/src/content/wage/wage.dto.ts
+++ b/src/backend/src/content/wage/wage.dto.ts
@@ -1,5 +1,20 @@
 import { Field, Float, InputType, Int, ObjectType } from "@nestjs/graphql";
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from "class-validator";
 import { ContentStatus } from "@prisma/client";
+import { Type } from "class-transformer";
+import { CONTENT_NAME_MAX_LENGTH } from "src/common/constants/content.constants";
 
 @InputType()
 export class ContentWageFilter {
@@ -7,18 +22,26 @@ export class ContentWageFilter {
     description: "귀속 아이템 포함 여부",
     nullable: true,
   })
+  @IsOptional()
+  @IsBoolean()
   includeBound?: boolean;
 
   @Field(() => [Number], {
     description: "포함할 아이템 ID 목록",
     nullable: true,
   })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Min(1, { each: true })
   includeItemIds?: number[];
 
   @Field(() => Boolean, {
     description: "추가 보상(더보기) 포함 여부",
     nullable: true,
   })
+  @IsOptional()
+  @IsBoolean()
   includeSeeMore?: boolean;
 }
 
@@ -28,12 +51,19 @@ export class ContentWageListFilter extends ContentWageFilter {
     description: "필터링할 컨텐츠 카테고리 ID",
     nullable: true,
   })
+  @IsOptional()
+  @IsNumber()
   contentCategoryId?: number;
 
   @Field(() => String, { description: "검색 키워드", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(CONTENT_NAME_MAX_LENGTH)
   keyword?: string;
 
   @Field(() => ContentStatus, { description: "컨텐츠 상태", nullable: true })
+  @IsOptional()
+  @IsEnum(ContentStatus)
   status?: ContentStatus;
 }
 
@@ -42,21 +72,35 @@ export class CalculateCustomContentWageInput {
   @Field(() => [CalculateCustomContentWageItemInput], {
     description: "아이템 목록",
   })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CalculateCustomContentWageItemInput)
   items: CalculateCustomContentWageItemInput[];
 
   @Field(() => Int, { description: "분" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   minutes: number;
 
   @Field(() => Int, { description: "초" })
+  @IsNumber()
+  @Min(0)
+  @Max(59)
   seconds: number;
 }
 
 @InputType()
 export class CalculateCustomContentWageItemInput {
   @Field({ description: "아이템 ID" })
+  @IsNumber()
+  @Min(1)
   id: number;
 
   @Field(() => Float, { description: "획득 수량" })
+  @IsNumber()
+  @Min(0)
   quantity: number;
 }
 

--- a/src/backend/src/exchange-rate/gold-exchange-rate.dto.spec.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.dto.spec.ts
@@ -1,0 +1,43 @@
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { EditGoldExchangeRateInput } from "./gold-exchange-rate.dto";
+
+describe("EditGoldExchangeRateInput Validation", () => {
+  it("유효한 환율을 허용해야 함", async () => {
+    const input = plainToInstance(EditGoldExchangeRateInput, {
+      krwAmount: 500,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("krwAmount가 1 미만이면 에러", async () => {
+    const input = plainToInstance(EditGoldExchangeRateInput, {
+      krwAmount: 0,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("krwAmount");
+  });
+
+  it("krwAmount가 음수면 에러", async () => {
+    const input = plainToInstance(EditGoldExchangeRateInput, {
+      krwAmount: -1,
+    });
+
+    const errors = await validate(input);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe("krwAmount");
+  });
+
+  it("krwAmount가 1이면 허용 (경계값)", async () => {
+    const input = plainToInstance(EditGoldExchangeRateInput, {
+      krwAmount: 1,
+    });
+
+    const errors = await validate(input);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
@@ -1,8 +1,11 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
+import { IsNumber, Min } from "class-validator";
 
 @InputType()
 export class EditGoldExchangeRateInput {
   @Field(() => Int, { description: "100골드당 원화 금액" })
+  @IsNumber()
+  @Min(1)
   krwAmount: number;
 }
 

--- a/src/backend/src/item/auction-item/auction-item.dto.ts
+++ b/src/backend/src/item/auction-item/auction-item.dto.ts
@@ -1,4 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
+import { IsBoolean, IsOptional, IsString, MaxLength } from "class-validator";
+import { ITEM_KEYWORD_MAX_LENGTH } from "src/common/constants/item.constants";
 
 @InputType()
 export class AuctionItemListFilter {
@@ -6,11 +8,16 @@ export class AuctionItemListFilter {
     description: "가격 통계 수집 활성화 여부",
     nullable: true,
   })
+  @IsOptional()
+  @IsBoolean()
   isStatScraperEnabled?: boolean;
 
   @Field(() => String, {
     description: "아이템 이름 검색 키워드",
     nullable: true,
   })
+  @IsOptional()
+  @IsString()
+  @MaxLength(ITEM_KEYWORD_MAX_LENGTH)
   nameKeyword?: string;
 }

--- a/src/backend/src/item/market-item/market-item.dto.ts
+++ b/src/backend/src/item/market-item/market-item.dto.ts
@@ -1,19 +1,36 @@
 import { Field, InputType } from "@nestjs/graphql";
+import { IsBoolean, IsOptional, IsString, MaxLength } from "class-validator";
+import {
+  ITEM_CATEGORY_NAME_MAX_LENGTH,
+  ITEM_GRADE_MAX_LENGTH,
+  ITEM_KEYWORD_MAX_LENGTH,
+} from "src/common/constants/item.constants";
 
 @InputType()
 export class MarketItemListFilter {
   @Field({ description: "카테고리 이름", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(ITEM_CATEGORY_NAME_MAX_LENGTH)
   categoryName?: string;
 
   @Field({ description: "등급", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(ITEM_GRADE_MAX_LENGTH)
   grade?: string;
 
   @Field(() => Boolean, {
     description: "가격 통계 수집 활성화 여부",
     nullable: true,
   })
+  @IsOptional()
+  @IsBoolean()
   isStatScraperEnabled?: boolean;
 
   @Field({ description: "검색 키워드", nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(ITEM_KEYWORD_MAX_LENGTH)
   keyword?: string;
 }

--- a/src/backend/src/main.ts
+++ b/src/backend/src/main.ts
@@ -1,9 +1,22 @@
+import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import "./enums";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      skipNullProperties: true, // null 값 검증 스킵
+      skipUndefinedProperties: true, // undefined 값 검증 스킵 (GraphQL optional 필드)
+      transform: true, // DTO 클래스 인스턴스로 변환 (중첩 객체 검증에 필요)
+      transformOptions: {
+        enableImplicitConversion: true, // GraphQL 스칼라 타입 자동 변환 허용
+      },
+      whitelist: false, // 선언되지 않은 속성 제거 안 함 (GraphQL과 충돌 방지)
+    })
+  );
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
전역 ValidationPipe를 적용하고 모든 InputType에 class-validator 데코레이터를 추가하여 입력 데이터 검증을 자동화

- class-validator 및 class-transformer 의존성 추가
- 25개 InputType에 타입, 범위, 구조 검증 데코레이터 적용
- GraphQL 호환 ValidationPipe 설정 (optional 필드 처리)
- 비즈니스 규칙 검증 자동화 (레벨 1-1700, 시간 형식, ID 양수 등)

fix #226