### PR TITLE
refactor(backend): contentList query에 정렬 기능 추가

### DIFF
--- a/src/backend/schema.graphql
+++ b/src/backend/schema.graphql
@@ -475,7 +475,10 @@ type Mutation {
 }
 
 input OrderByArg {
+  """정렬 필드명"""
   field: String!
+
+  """정렬 방향 (asc 또는 desc)"""
   order: String!
 }
 
@@ -487,7 +490,7 @@ type Query {
   contentDuration(id: Int!): ContentDuration!
   contentGroup(filter: ContentGroupFilter): ContentGroup!
   contentGroupWageList(filter: ContentGroupWageListFilter, orderBy: [OrderByArg!]): [ContentGroupWage!]!
-  contentList(filter: ContentListFilter): [Content!]!
+  contentList(filter: ContentListFilter, orderBy: [OrderByArg!]): [Content!]!
   contentWageList(filter: ContentWageListFilter, orderBy: [OrderByArg!]): [ContentWage!]!
   contents(filter: ContentsFilter): [Content!]!
   goldExchangeRate: GoldExchangeRate!

--- a/src/backend/src/common/object/order-by-arg.object.ts
+++ b/src/backend/src/common/object/order-by-arg.object.ts
@@ -1,11 +1,15 @@
 import { Field, InputType } from "@nestjs/graphql";
 import { Prisma } from "@prisma/client";
+import { IsIn, IsString } from "class-validator";
 
 @InputType()
 export class OrderByArg {
-  @Field()
+  @Field({ description: "정렬 필드명" })
+  @IsString()
   field: string;
 
-  @Field(() => String)
+  @Field(() => String, { description: "정렬 방향 (asc 또는 desc)" })
+  @IsString()
+  @IsIn(["asc", "desc"])
   order: Prisma.SortOrder;
 }

--- a/src/backend/src/content/content/content.resolver.ts
+++ b/src/backend/src/content/content/content.resolver.ts
@@ -1,6 +1,7 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { AuthGuard } from "src/auth/auth.guard";
+import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { DataLoaderService } from "src/dataloader/data-loader.service";
 import { UserContentService } from "src/user/service/user-content.service";
 import { ContentCategory } from "../category/category.object";
@@ -33,8 +34,11 @@ export class ContentResolver {
   }
 
   @Query(() => [Content])
-  async contentList(@Args("filter", { nullable: true }) filter?: ContentListFilter) {
-    return await this.contentService.findContentList(filter);
+  async contentList(
+    @Args("filter", { nullable: true }) filter?: ContentListFilter,
+    @Args("orderBy", { nullable: true, type: () => [OrderByArg] }) orderBy?: OrderByArg[]
+  ) {
+    return await this.contentService.findContentList(filter, orderBy);
   }
 
   @Query(() => [Content])

--- a/src/backend/src/content/content/content.service.ts
+++ b/src/backend/src/content/content/content.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Content, Prisma } from "@prisma/client";
+import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { NotFoundException } from "src/common/exception/not-found.exception";
 import { PrismaService } from "src/prisma";
 import {
@@ -58,6 +59,26 @@ export class ContentService {
     }
 
     return where;
+  }
+
+  buildOrderBy(orderBy?: OrderByArg[]): Prisma.ContentOrderByWithRelationInput[] {
+    if (orderBy && orderBy.length > 0) {
+      return orderBy.map((order) => ({ [order.field]: order.order }));
+    }
+
+    return [
+      {
+        contentCategory: {
+          id: "asc",
+        },
+      },
+      {
+        level: "asc",
+      },
+      {
+        id: "asc",
+      },
+    ];
   }
 
   async createContent(input: CreateContentInput): Promise<CreateContentResult> {
@@ -123,21 +144,9 @@ export class ContentService {
     return content;
   }
 
-  async findContentList(filter?: ContentListFilter): Promise<Content[]> {
+  async findContentList(filter?: ContentListFilter, orderBy?: OrderByArg[]): Promise<Content[]> {
     return await this.prisma.content.findMany({
-      orderBy: [
-        {
-          contentCategory: {
-            id: "asc",
-          },
-        },
-        {
-          level: "asc",
-        },
-        {
-          id: "asc",
-        },
-      ],
+      orderBy: this.buildOrderBy(orderBy),
       where: this.buildContentListWhere(filter),
     });
   }

--- a/src/frontend/src/core/graphql/generated.tsx
+++ b/src/frontend/src/core/graphql/generated.tsx
@@ -504,7 +504,9 @@ export type MutationUserItemPriceEditArgs = {
 };
 
 export type OrderByArg = {
+  /** 정렬 필드명 */
   field: Scalars['String']['input'];
+  /** 정렬 방향 (asc 또는 desc) */
   order: Scalars['String']['input'];
 };
 
@@ -563,6 +565,7 @@ export type QueryContentGroupWageListArgs = {
 
 export type QueryContentListArgs = {
   filter?: InputMaybe<ContentListFilter>;
+  orderBy?: InputMaybe<Array<OrderByArg>>;
 };
 
 


### PR DESCRIPTION
- OrderByArg에 class-validator 데코레이터 추가 (@IsString, @IsIn)
- contentList query에 orderBy 파라미터 적용 (OrderByArg[] 배열 타입)
- ContentService에 buildOrderBy 메서드 구현 (다중 필드 정렬 지원)
- 기본 정렬 로직 유지 (contentCategory > level > id)

fix #227