### PR TITLE
refactor(backend): Mutation 응답 타입 표준화

### DIFF
--- a/src/backend/src/common/dto/mutation-result.dto.ts
+++ b/src/backend/src/common/dto/mutation-result.dto.ts
@@ -1,0 +1,7 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType({ isAbstract: true })
+export abstract class MutationResult {
+  @Field(() => Boolean, { description: "성공 여부" })
+  ok: boolean;
+}

--- a/src/backend/src/content/content/content.dto.ts
+++ b/src/backend/src/content/content/content.dto.ts
@@ -16,6 +16,7 @@ import {
 import { ContentStatus } from "@prisma/client";
 import { Type } from "class-transformer";
 import { CONTENT_LEVEL_MAX, CONTENT_NAME_MAX_LENGTH } from "src/common/constants/content.constants";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class ContentListFilter {
@@ -147,7 +148,4 @@ export class CreateContentSeeMoreRewardInput {
 }
 
 @ObjectType()
-export class CreateContentResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class CreateContentResult extends MutationResult {}

--- a/src/backend/src/content/duration/duration.dto.ts
+++ b/src/backend/src/content/duration/duration.dto.ts
@@ -1,6 +1,7 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
 import { ArrayMinSize, IsArray, IsNumber, Max, Min, ValidateNested } from "class-validator";
 import { Type } from "class-transformer";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class EditContentDurationInput {
@@ -23,10 +24,7 @@ export class EditContentDurationInput {
 }
 
 @ObjectType()
-export class EditContentDurationResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditContentDurationResult extends MutationResult {}
 
 @InputType()
 export class EditContentDurationsDurationInput {
@@ -61,7 +59,4 @@ export class EditContentDurationsInput {
 }
 
 @ObjectType()
-export class EditContentDurationsResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditContentDurationsResult extends MutationResult {}

--- a/src/backend/src/content/item/item.dto.ts
+++ b/src/backend/src/content/item/item.dto.ts
@@ -2,6 +2,7 @@ import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
 import { IsEnum, IsNumber, IsOptional, IsString, MaxLength, Min } from "class-validator";
 import { ItemKind } from "@prisma/client";
 import { ITEM_KEYWORD_MAX_LENGTH } from "src/common/constants/item.constants";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class ItemsFilter {
@@ -31,7 +32,4 @@ export class EditUserItemPriceInput {
 }
 
 @ObjectType()
-export class EditUserItemPriceResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditUserItemPriceResult extends MutationResult {}

--- a/src/backend/src/content/reward/reward.dto.ts
+++ b/src/backend/src/content/reward/reward.dto.ts
@@ -1,6 +1,7 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
 import { ArrayMinSize, IsArray, IsBoolean, IsNumber, Min, ValidateNested } from "class-validator";
 import { Type } from "class-transformer";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class EditContentRewardInput {
@@ -41,10 +42,7 @@ export class EditContentRewardsInput {
 }
 
 @ObjectType()
-export class EditContentRewardsResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditContentRewardsResult extends MutationResult {}
 
 @InputType()
 export class ReportContentRewardInput {
@@ -72,7 +70,4 @@ export class ReportContentRewardsInput {
 }
 
 @ObjectType()
-export class ReportContentRewardsResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class ReportContentRewardsResult extends MutationResult {}

--- a/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.dto.ts
@@ -1,6 +1,7 @@
 import { Field, Float, InputType, ObjectType } from "@nestjs/graphql";
 import { ArrayMinSize, IsArray, IsNumber, Min, ValidateNested } from "class-validator";
 import { Type } from "class-transformer";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class EditContentSeeMoreRewardInput {
@@ -33,7 +34,4 @@ export class EditContentSeeMoreRewardsInput {
 }
 
 @ObjectType()
-export class EditContentSeeMoreRewardsResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditContentSeeMoreRewardsResult extends MutationResult {}

--- a/src/backend/src/content/wage/wage.dto.ts
+++ b/src/backend/src/content/wage/wage.dto.ts
@@ -15,6 +15,7 @@ import {
 import { ContentStatus } from "@prisma/client";
 import { Type } from "class-transformer";
 import { CONTENT_NAME_MAX_LENGTH } from "src/common/constants/content.constants";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class ContentWageFilter {
@@ -105,7 +106,7 @@ export class CalculateCustomContentWageItemInput {
 }
 
 @ObjectType()
-export class CalculateCustomContentWageResult {
+export class CalculateCustomContentWageResult extends MutationResult {
   @Field({ description: "회당 골드 획득량" })
   goldAmountPerClear: number;
 
@@ -114,7 +115,4 @@ export class CalculateCustomContentWageResult {
 
   @Field({ description: "시급 (원화)" })
   krwAmountPerHour: number;
-
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
 }

--- a/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.dto.ts
@@ -1,5 +1,6 @@
 import { Field, InputType, Int, ObjectType } from "@nestjs/graphql";
 import { IsNumber, Min } from "class-validator";
+import { MutationResult } from "src/common/dto/mutation-result.dto";
 
 @InputType()
 export class EditGoldExchangeRateInput {
@@ -10,7 +11,4 @@ export class EditGoldExchangeRateInput {
 }
 
 @ObjectType()
-export class EditGoldExchangeRateResult {
-  @Field(() => Boolean, { description: "성공 여부" })
-  ok: boolean;
-}
+export class EditGoldExchangeRateResult extends MutationResult {}


### PR DESCRIPTION
모든 Mutation Result 타입에서 중복되던 ok 필드 정의를 MutationResult 기반 클래스로 통합하여 일관성 확보

- common/dto/mutation-result.dto.ts 생성 (ok 필드만 포함)
- 9개 Result 타입이 MutationResult 상속하도록 변경

fix #229