### PR TITLE
refactor(backend): Service 계층의 GraphQL Context 의존성 제거

### DIFF
--- a/src/backend/src/content/content/content.resolver.ts
+++ b/src/backend/src/content/content/content.resolver.ts
@@ -1,6 +1,8 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { User } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
+import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { DataLoaderService } from "src/dataloader/data-loader.service";
 import { UserContentService } from "src/user/service/user-content.service";
@@ -76,8 +78,8 @@ export class ContentResolver {
   }
 
   @ResolveField(() => Number)
-  async duration(@Parent() content: Content) {
-    return await this.userContentService.getContentDuration(content.id);
+  async duration(@Parent() content: Content, @CurrentUser() user?: User) {
+    return await this.userContentService.getContentDuration(content.id, user?.id);
   }
 
   @ResolveField(() => String)
@@ -92,8 +94,9 @@ export class ContentResolver {
   @ResolveField(() => ContentWage)
   async wage(
     @Parent() content: Content,
-    @Args("filter", { nullable: true }) filter?: ContentWageFilter
+    @Args("filter", { nullable: true }) filter?: ContentWageFilter,
+    @CurrentUser() user?: User
   ) {
-    return await this.contentWageService.getContentWage(content.id, filter);
+    return await this.contentWageService.getContentWage(content.id, user?.id, filter);
   }
 }

--- a/src/backend/src/content/group/group.resolver.ts
+++ b/src/backend/src/content/group/group.resolver.ts
@@ -1,4 +1,6 @@
 import { Args, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { User } from "@prisma/client";
+import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { DataLoaderService } from "src/dataloader/data-loader.service";
 import { ContentCategory } from "../category/category.object";
@@ -26,9 +28,10 @@ export class GroupResolver {
       nullable: true,
       type: () => [OrderByArg],
     })
-    orderBy?: OrderByArg[]
+    orderBy?: OrderByArg[],
+    @CurrentUser() user?: User
   ) {
-    return await this.groupService.findContentGroupWageList(filter, orderBy);
+    return await this.groupService.findContentGroupWageList(filter, orderBy, user?.id);
   }
 
   @ResolveField(() => ContentCategory)

--- a/src/backend/src/content/group/group.service.spec.ts
+++ b/src/backend/src/content/group/group.service.spec.ts
@@ -380,7 +380,7 @@ describe("GroupService", () => {
         includeSeeMore: true,
       });
 
-      expect(contentWageService.getContentGroupWage).toHaveBeenCalledWith([1], {
+      expect(contentWageService.getContentGroupWage).toHaveBeenCalledWith([1], undefined, {
         includeBound: false,
         includeItemIds: [1, 2, 3],
         includeSeeMore: true,

--- a/src/backend/src/content/group/group.service.ts
+++ b/src/backend/src/content/group/group.service.ts
@@ -91,7 +91,8 @@ export class GroupService {
 
   async findContentGroupWageList(
     filter?: ContentGroupWageListFilter,
-    orderBy?: OrderByArg[]
+    orderBy?: OrderByArg[],
+    userId?: number
   ): Promise<ContentGroupWage[]> {
     const contents = await this.prisma.content.findMany({
       include: {
@@ -112,7 +113,7 @@ export class GroupService {
       const contentIds = groupContents.map((content) => content.id);
       const representative = groupContents[0];
 
-      const wage = await this.contentWageService.getContentGroupWage(contentIds, {
+      const wage = await this.contentWageService.getContentGroupWage(contentIds, userId, {
         includeBound: filter?.includeBound,
         includeItemIds: filter?.includeItemIds,
         includeSeeMore: filter?.includeSeeMore,

--- a/src/backend/src/content/item/item.resolver.ts
+++ b/src/backend/src/content/item/item.resolver.ts
@@ -1,5 +1,6 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Float, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { User as PrismaUser } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
@@ -29,13 +30,16 @@ export class ItemResolver {
 
   @UseGuards(AuthGuard)
   @Mutation(() => EditUserItemPriceResult)
-  async userItemPriceEdit(@Args("input") input: EditUserItemPriceInput) {
-    return await this.itemService.editUserItemPrice(input);
+  async userItemPriceEdit(
+    @Args("input") input: EditUserItemPriceInput,
+    @CurrentUser() user: PrismaUser
+  ) {
+    return await this.itemService.editUserItemPrice(input, user.id);
   }
 
   @ResolveField(() => Float)
-  async price(@Parent() item: Item) {
-    return await this.userContentService.getItemPrice(item.id);
+  async price(@Parent() item: Item, @CurrentUser() user?: PrismaUser) {
+    return await this.userContentService.getItemPrice(item.id, user?.id);
   }
 
   @UseGuards(AuthGuard)

--- a/src/backend/src/content/item/item.service.ts
+++ b/src/backend/src/content/item/item.service.ts
@@ -29,10 +29,13 @@ export class ItemService {
     return where;
   }
 
-  async editUserItemPrice(input: EditUserItemPriceInput): Promise<EditUserItemPriceResult> {
+  async editUserItemPrice(
+    input: EditUserItemPriceInput,
+    userId: number
+  ): Promise<EditUserItemPriceResult> {
     const { id, price } = input;
 
-    await this.userContentService.validateUserItem(id);
+    await this.userContentService.validateUserItem(id, userId);
 
     await this.prisma.userItem.update({
       data: { price },

--- a/src/backend/src/content/reward/reward.resolver.ts
+++ b/src/backend/src/content/reward/reward.resolver.ts
@@ -1,5 +1,6 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Float, Mutation, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { User as PrismaUser } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
@@ -42,13 +43,16 @@ export class RewardResolver {
   }
 
   @ResolveField(() => Float)
-  async averageQuantity(@Parent() contentReward: ContentReward) {
-    return await this.userContentService.getContentRewardAverageQuantity(contentReward.id);
+  async averageQuantity(@Parent() contentReward: ContentReward, @CurrentUser() user?: PrismaUser) {
+    return await this.userContentService.getContentRewardAverageQuantity(
+      contentReward.id,
+      user?.id
+    );
   }
 
   @ResolveField(() => Boolean)
-  async isSellable(@Parent() contentReward: ContentReward) {
-    return await this.userContentService.getContentRewardIsSellable(contentReward.id);
+  async isSellable(@Parent() contentReward: ContentReward, @CurrentUser() user?: PrismaUser) {
+    return await this.userContentService.getContentRewardIsSellable(contentReward.id, user?.id);
   }
 
   @ResolveField(() => Item)

--- a/src/backend/src/content/see-more-reward/see-more-reward.resolver.ts
+++ b/src/backend/src/content/see-more-reward/see-more-reward.resolver.ts
@@ -1,5 +1,6 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Float, Mutation, Parent, ResolveField, Resolver } from "@nestjs/graphql";
+import { User as PrismaUser } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
@@ -36,7 +37,13 @@ export class SeeMoreRewardResolver {
   }
 
   @ResolveField(() => Float)
-  async quantity(@Parent() contentSeeMoreReward: ContentSeeMoreReward) {
-    return await this.userContentService.getContentSeeMoreRewardQuantity(contentSeeMoreReward.id);
+  async quantity(
+    @Parent() contentSeeMoreReward: ContentSeeMoreReward,
+    @CurrentUser() user?: PrismaUser
+  ) {
+    return await this.userContentService.getContentSeeMoreRewardQuantity(
+      contentSeeMoreReward.id,
+      user?.id
+    );
   }
 }

--- a/src/backend/src/exchange-rate/gold-exchange-rate.resolver.ts
+++ b/src/backend/src/exchange-rate/gold-exchange-rate.resolver.ts
@@ -1,5 +1,6 @@
 import { UseGuards } from "@nestjs/common";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { User as PrismaUser } from "@prisma/client";
 import { AuthGuard } from "src/auth/auth.guard";
 import { CurrentUser } from "src/common/decorator/current-user.decorator";
 import { User } from "src/common/object/user.object";
@@ -16,8 +17,8 @@ export class GoldExchangeRateResolver {
   ) {}
 
   @Query(() => GoldExchangeRate)
-  async goldExchangeRate() {
-    return await this.userGoldExchangeRateService.getGoldExchangeRate();
+  async goldExchangeRate(@CurrentUser() user?: PrismaUser) {
+    return await this.userGoldExchangeRateService.getGoldExchangeRate(user?.id);
   }
 
   @UseGuards(AuthGuard)

--- a/src/backend/src/user/service/types.ts
+++ b/src/backend/src/user/service/types.ts
@@ -1,1 +1,0 @@
-export type ContextType = { req?: { user?: { id: number } } };

--- a/src/backend/src/user/service/user-content.service.spec.ts
+++ b/src/backend/src/user/service/user-content.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/prisma";
 import { UserContentService } from "../../user/service/user-content.service";
-import { CONTEXT } from "@nestjs/graphql";
 import { UserGoldExchangeRateService } from "src/user/service/user-gold-exchange-rate.service";
 import { User } from "@prisma/client";
 import { ContentWageService } from "src/content/wage/wage.service";
@@ -34,10 +33,6 @@ describe("UserContentService", () => {
         ContentFactory,
         ContentDurationFactory,
         ContentRewardFactory,
-        {
-          provide: CONTEXT,
-          useValue: { req: { user: { id: undefined } } },
-        },
       ],
     }).compile();
 
@@ -167,7 +162,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id, {
+      const results = await service.getContentRewards(content.id, undefined, {
         includeBound: false,
       });
 
@@ -213,7 +208,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id, {
+      const results = await service.getContentRewards(content.id, undefined, {
         includeItemIds: [item1.id, item3.id],
       });
 
@@ -264,7 +259,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id, {
+      const results = await service.getContentRewards(content.id, undefined, {
         includeBound: false,
         includeItemIds: [item1.id, item2.id],
       });
@@ -293,7 +288,6 @@ describe("UserContentService", () => {
 
     beforeAll(async () => {
       user = await userFactory.create();
-      service["context"].req.user = { id: user.id };
     });
 
     it("getItemPrice", async () => {
@@ -313,7 +307,7 @@ describe("UserContentService", () => {
         },
       });
 
-      const result = await service.getItemPrice(item.id);
+      const result = await service.getItemPrice(item.id, user.id);
 
       expect(result).toBe(userPrice);
     });
@@ -327,7 +321,7 @@ describe("UserContentService", () => {
         },
       });
 
-      const result = await service.getItemPrice(item.id);
+      const result = await service.getItemPrice(item.id, user.id);
 
       expect(result).toBe(price);
     });
@@ -349,7 +343,7 @@ describe("UserContentService", () => {
         },
       });
 
-      const result = await service.getContentDuration(content.id);
+      const result = await service.getContentDuration(content.id, user.id);
       expect(result).toBe(duration);
     });
 
@@ -366,7 +360,7 @@ describe("UserContentService", () => {
         },
       });
 
-      const result = await service.getContentRewardAverageQuantity(contentReward.id);
+      const result = await service.getContentRewardAverageQuantity(contentReward.id, user.id);
 
       expect(result.toNumber()).toBeCloseTo(averageQuantity, 5);
     });
@@ -423,7 +417,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id);
+      const results = await service.getContentRewards(content.id, user.id);
 
       expect(results).toHaveLength(2);
 
@@ -486,7 +480,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id, {
+      const results = await service.getContentRewards(content.id, user.id, {
         includeBound: false,
       });
 
@@ -555,7 +549,7 @@ describe("UserContentService", () => {
         ],
       });
 
-      const results = await service.getContentRewards(content.id, {
+      const results = await service.getContentRewards(content.id, user.id, {
         includeItemIds: [item1.id, item3.id],
       });
 
@@ -613,7 +607,7 @@ describe("UserContentService", () => {
         },
       });
 
-      const results = await service.getContentRewards(content.id);
+      const results = await service.getContentRewards(content.id, user.id);
 
       expect(results).toHaveLength(1);
       expect(results[0].itemId).toBe(item.id);

--- a/src/backend/src/user/service/user-content.service.ts
+++ b/src/backend/src/user/service/user-content.service.ts
@@ -1,20 +1,11 @@
-import { Inject, Injectable, UseGuards } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../../prisma";
-import { CONTEXT } from "@nestjs/graphql";
-import { ContextType } from "./types";
-import { AuthGuard } from "src/auth/auth.guard";
 
-@UseGuards(AuthGuard)
 @Injectable()
 export class UserContentService {
-  constructor(
-    private readonly prisma: PrismaService,
-    @Inject(CONTEXT) private context: ContextType
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
-  async getContentDuration(contentId: number) {
-    const userId = this.getUserId();
-
+  async getContentDuration(contentId: number, userId?: number) {
     const contentDuration = await this.prisma.contentDuration.findUniqueOrThrow({
       where: {
         contentId,
@@ -37,9 +28,7 @@ export class UserContentService {
     return contentDuration.value;
   }
 
-  async getContentRewardAverageQuantity(contentRewardId: number) {
-    const userId = this.getUserId();
-
+  async getContentRewardAverageQuantity(contentRewardId: number, userId?: number) {
     const contentReward = await this.prisma.contentReward.findUniqueOrThrow({
       where: {
         id: contentRewardId,
@@ -63,9 +52,7 @@ export class UserContentService {
     return contentReward.averageQuantity;
   }
 
-  async getContentRewardIsSellable(contentRewardId: number) {
-    const userId = this.getUserId();
-
+  async getContentRewardIsSellable(contentRewardId: number, userId?: number) {
     const contentReward = await this.prisma.contentReward.findUniqueOrThrow({
       where: { id: contentRewardId },
     });
@@ -89,13 +76,12 @@ export class UserContentService {
 
   async getContentRewards(
     contentId: number,
+    userId?: number,
     filter?: {
       includeBound?: boolean;
       includeItemIds?: number[];
     }
   ) {
-    const userId = this.getUserId();
-
     const where = {
       contentId,
       ...(filter?.includeItemIds && {
@@ -159,9 +145,7 @@ export class UserContentService {
     });
   }
 
-  async getContentSeeMoreRewardQuantity(contentSeeMoreRewardId: number) {
-    const userId = this.getUserId();
-
+  async getContentSeeMoreRewardQuantity(contentSeeMoreRewardId: number, userId?: number) {
     const contentSeeMoreReward = await this.prisma.contentSeeMoreReward.findUniqueOrThrow({
       where: { id: contentSeeMoreRewardId },
     });
@@ -187,12 +171,11 @@ export class UserContentService {
 
   async getContentSeeMoreRewards(
     contentId: number,
+    userId?: number,
     filter?: {
       includeItemIds?: number[];
     }
   ) {
-    const userId = this.getUserId();
-
     const where = {
       contentId,
       ...(filter?.includeItemIds && {
@@ -233,9 +216,7 @@ export class UserContentService {
   }
 
   //  Test 작성
-  async getItemPrice(itemId: number) {
-    const userId = this.getUserId();
-
+  async getItemPrice(itemId: number, userId?: number) {
     const { price: defaultPrice } = await this.prisma.item.findUniqueOrThrow({
       where: {
         id: itemId,
@@ -265,13 +246,7 @@ export class UserContentService {
     return price.toNumber();
   }
 
-  getUserId() {
-    return this.context.req?.user?.id;
-  }
-
-  async validateUserItem(itemId: number) {
-    const userId = this.getUserId();
-
+  async validateUserItem(itemId: number, userId: number) {
     const userItem = await this.prisma.userItem.findUnique({
       where: { id: itemId, userId },
     });

--- a/src/backend/src/user/service/user-gold-exchange-rate.service.spec.ts
+++ b/src/backend/src/user/service/user-gold-exchange-rate.service.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/prisma";
-import { CONTEXT } from "@nestjs/graphql";
 import { UserGoldExchangeRateService } from "src/user/service/user-gold-exchange-rate.service";
 import { UserFactory } from "src/test/factory/user.factory";
 import { User } from "@prisma/client";
@@ -13,15 +12,7 @@ describe("UserGoldExchangeRateService", () => {
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
-      providers: [
-        PrismaService,
-        UserGoldExchangeRateService,
-        UserFactory,
-        {
-          provide: CONTEXT,
-          useValue: { req: { user: { id: undefined } } },
-        },
-      ],
+      providers: [PrismaService, UserGoldExchangeRateService, UserFactory],
     }).compile();
 
     service = module.get(UserGoldExchangeRateService);
@@ -40,7 +31,6 @@ describe("UserGoldExchangeRateService", () => {
 
     beforeAll(async () => {
       user = await userFactory.create();
-      service["context"].req.user = { id: user.id };
 
       await prisma.goldExchangeRate.create({
         data: {
@@ -60,7 +50,7 @@ describe("UserGoldExchangeRateService", () => {
 
     describe("getGoldExchangeRate", () => {
       it("basic", async () => {
-        const result = await service.getGoldExchangeRate();
+        const result = await service.getGoldExchangeRate(user.id);
 
         expect(result.goldAmount).toEqual(userGoldAmount);
         expect(result.krwAmount).toEqual(userKrwAmount);
@@ -71,10 +61,6 @@ describe("UserGoldExchangeRateService", () => {
   describe("not logged in", () => {
     const goldAmount = 100;
     const krwAmount = 25;
-
-    beforeAll(async () => {
-      service["context"].req.user = { id: undefined };
-    });
 
     describe("getGoldExchangeRate", () => {
       beforeAll(async () => {

--- a/src/backend/src/user/service/user-gold-exchange-rate.service.ts
+++ b/src/backend/src/user/service/user-gold-exchange-rate.service.ts
@@ -1,20 +1,11 @@
-import { Inject, Injectable, UseGuards } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { PrismaService } from "../../prisma";
-import { CONTEXT } from "@nestjs/graphql";
-import { ContextType } from "./types";
-import { AuthGuard } from "src/auth/auth.guard";
 
-@UseGuards(AuthGuard)
 @Injectable()
 export class UserGoldExchangeRateService {
-  constructor(
-    private readonly prisma: PrismaService,
-    @Inject(CONTEXT) private context: ContextType
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
-  async getGoldExchangeRate() {
-    const userId = this.getUserId();
-
+  async getGoldExchangeRate(userId?: number) {
     const goldExchangeRate = await this.prisma.goldExchangeRate.findFirstOrThrow();
 
     if (userId) {
@@ -28,9 +19,5 @@ export class UserGoldExchangeRateService {
     }
 
     return goldExchangeRate;
-  }
-
-  private getUserId() {
-    return this.context.req?.user?.id;
   }
 }


### PR DESCRIPTION
Service 계층이 GraphQL Context에 직접 의존하여 테스트 작성이 어렵고 재사용성이 낮았던 문제 해결

- UserContentService, UserGoldExchangeRateService에서 @Inject(CONTEXT) 제거
- userId를 명시적 파라미터로 받도록 메서드 시그니처 변경
- Resolver에서 @CurrentUser() 데코레이터로 userId 추출 후 Service에 전달
- ContentWageService, ItemService 등 downstream services도 userId 전파하도록 업데이트
- ContextType 정의 파일 제거

이를 통해 Service 계층의 테스트 가능성과 재사용성이 향상되고, GraphQL 이외의 컨텍스트(REST API, CLI 등)에서도 Service를 사용할 수 있게 됨

fix #230