### PR TITLE
refactor(backend): 서비스 계층 코드 중복 제거 및 구조 개선

### DIFF
--- a/src/backend/src/content/content/content.service.ts
+++ b/src/backend/src/content/content/content.service.ts
@@ -3,6 +3,7 @@ import { Content, Prisma } from "@prisma/client";
 import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { NotFoundException } from "src/common/exception/not-found.exception";
 import { PrismaService } from "src/prisma";
+import { DEFAULT_CONTENT_ORDER_BY } from "../shared/constants";
 import {
   ContentListFilter,
   ContentsFilter,
@@ -66,19 +67,7 @@ export class ContentService {
       return orderBy.map((order) => ({ [order.field]: order.order }));
     }
 
-    return [
-      {
-        contentCategory: {
-          id: "asc",
-        },
-      },
-      {
-        level: "asc",
-      },
-      {
-        id: "asc",
-      },
-    ];
+    return DEFAULT_CONTENT_ORDER_BY;
   }
 
   async createContent(input: CreateContentInput): Promise<CreateContentResult> {
@@ -153,19 +142,7 @@ export class ContentService {
 
   async findContents(filter?: ContentsFilter): Promise<Content[]> {
     return await this.prisma.content.findMany({
-      orderBy: [
-        {
-          contentCategory: {
-            id: "asc",
-          },
-        },
-        {
-          level: "asc",
-        },
-        {
-          id: "asc",
-        },
-      ],
+      orderBy: DEFAULT_CONTENT_ORDER_BY,
       where: this.buildContentsWhere(filter),
     });
   }

--- a/src/backend/src/content/group/group.service.ts
+++ b/src/backend/src/content/group/group.service.ts
@@ -5,6 +5,7 @@ import { ValidationException } from "src/common/exception";
 import { OrderByArg } from "src/common/object/order-by-arg.object";
 import { PrismaService } from "src/prisma";
 import { UserContentService } from "src/user/service/user-content.service";
+import { DEFAULT_CONTENT_ORDER_BY } from "../shared/constants";
 import { ContentWageService } from "../wage/wage.service";
 import { ContentGroupFilter, ContentGroupWageListFilter } from "./group.dto";
 import { ContentGroup, ContentGroupWage } from "./group.object";
@@ -171,19 +172,7 @@ export class GroupService {
   }
 
   private getContentOrderBy(): Prisma.ContentOrderByWithRelationInput[] {
-    return [
-      {
-        contentCategory: {
-          id: "asc",
-        },
-      },
-      {
-        level: "asc",
-      },
-      {
-        id: "asc",
-      },
-    ];
+    return DEFAULT_CONTENT_ORDER_BY;
   }
 
   private sortResults(results: ContentGroupWage[], orderBy: OrderByArg[]): ContentGroupWage[] {

--- a/src/backend/src/content/shared/constants.ts
+++ b/src/backend/src/content/shared/constants.ts
@@ -1,3 +1,17 @@
+import { Prisma } from "@prisma/client";
+
+/**
+ * Content 기본 정렬 순서
+ * - 카테고리 ID 오름차순
+ * - 레벨 오름차순
+ * - ID 오름차순
+ */
+export const DEFAULT_CONTENT_ORDER_BY: Prisma.ContentOrderByWithRelationInput[] = [
+  { contentCategory: { id: "asc" } },
+  { level: "asc" },
+  { id: "asc" },
+];
+
 // 추후 유지보수성이 확실치 않은 데이터 구조 및 순서라 db에서 관리하지 않고 임시로 상수로 보상 아이템 순서를 관리함.
 export const ItemSortOrder = {
   "1레벨 보석": 7,


### PR DESCRIPTION
- UserContentService: getUserOverride 제네릭 헬퍼로 4개 메서드의 반복 패턴 통합
- UserContentService: getItemPrice 중복 DB 쿼리 제거 (2회→1회)
- ContentWageService: calculateContentWageData로 80% 중복 로직 통합
- ContentWageService: Promise.all로 병렬 처리 개선
- 공통 상수 DEFAULT_CONTENT_ORDER_BY 추출 (ContentService, GroupService)
- 매직 넘버 SECONDS_PER_HOUR 상수화

fix #235