### PR TITLE
refactor(frontend): DataTable 컴포넌트에서 테이블 로직을 커스텀 훅으로 분리

### DIFF
--- a/src/frontend/src/components/table/hooks/index.tsx
+++ b/src/frontend/src/components/table/hooks/index.tsx
@@ -1,0 +1,2 @@
+export { getValueFromPath, useFavoriteRows } from "./use-favorite-rows";
+export { useTableSort } from "./use-table-sort";

--- a/src/frontend/src/components/table/hooks/use-favorite-rows.tsx
+++ b/src/frontend/src/components/table/hooks/use-favorite-rows.tsx
@@ -1,0 +1,50 @@
+import { partition } from "es-toolkit/array";
+import { get } from "es-toolkit/compat";
+import { useMemo } from "react";
+
+import { FavoriteValue } from "../favorite-control";
+
+const isFavoriteValue = (value: unknown): value is FavoriteValue => {
+  return typeof value === "string" || typeof value === "number";
+};
+
+type UseFavoriteRowsOptions<T> = {
+  favoriteKeyPath?: string;
+  favorites: FavoriteValue[];
+  rows: Array<{ data: T }>;
+};
+
+type UseFavoriteRowsReturn<T> = {
+  favoriteRows: Array<{ data: T }>;
+  hasFavoriteFeature: boolean;
+  normalRows: Array<{ data: T }>;
+};
+
+export const useFavoriteRows = <T,>({
+  favoriteKeyPath,
+  favorites,
+  rows,
+}: UseFavoriteRowsOptions<T>): UseFavoriteRowsReturn<T> => {
+  return useMemo(() => {
+    const hasFavoriteFeature = !!favoriteKeyPath && favorites.length > 0;
+
+    if (!hasFavoriteFeature) {
+      return {
+        favoriteRows: [],
+        hasFavoriteFeature: false,
+        normalRows: [...rows],
+      };
+    }
+
+    const [favoriteRows, normalRows] = partition(rows, (row) => {
+      const value = get(row.data, favoriteKeyPath);
+      return isFavoriteValue(value) && favorites.includes(value);
+    });
+
+    return {
+      favoriteRows,
+      hasFavoriteFeature,
+      normalRows,
+    };
+  }, [favoriteKeyPath, favorites, rows]);
+};

--- a/src/frontend/src/components/table/hooks/use-table-sort.tsx
+++ b/src/frontend/src/components/table/hooks/use-table-sort.tsx
@@ -1,0 +1,82 @@
+import { orderBy } from "es-toolkit/array";
+import { get } from "es-toolkit/compat";
+import { useCallback, useMemo, useState } from "react";
+
+type SortOrder = "asc" | "desc" | null;
+
+type UseTableSortOptions<T> = {
+  columns: Array<{
+    sortKey?: string;
+    sortValue?: (data: T) => number | string | null;
+  }>;
+  defaultSorting?: {
+    sortKey: string;
+    value: "asc" | "desc";
+  };
+};
+
+type UseTableSortReturn<T> = {
+  currentSortKey: string | null;
+  handleSort: (column: { sortKey?: string }) => void;
+  sortOrder: SortOrder;
+  sortRows: <R extends { data: T }>(rows: R[]) => R[];
+};
+
+export const useTableSort = <T,>({
+  columns,
+  defaultSorting,
+}: UseTableSortOptions<T>): UseTableSortReturn<T> => {
+  const [currentSortKey, setCurrentSortKey] = useState<string | null>(
+    defaultSorting?.sortKey || null
+  );
+  const [sortOrder, setSortOrder] = useState<SortOrder>(defaultSorting?.value || null);
+
+  const handleSort = useCallback(
+    (column: { sortKey?: string }) => {
+      if (!column.sortKey) return;
+
+      let newOrder: SortOrder;
+      if (currentSortKey !== column.sortKey) {
+        newOrder = "asc";
+      } else if (sortOrder === "asc") {
+        newOrder = "desc";
+      } else if (sortOrder === "desc") {
+        newOrder = null;
+      } else {
+        newOrder = "asc";
+      }
+
+      setCurrentSortKey(newOrder ? column.sortKey : null);
+      setSortOrder(newOrder);
+    },
+    [currentSortKey, sortOrder]
+  );
+
+  const sortRows = useMemo(() => {
+    const column = columns.find((col) => col.sortKey === currentSortKey);
+
+    return <R extends { data: T }>(rows: R[]): R[] => {
+      if (!currentSortKey || !sortOrder) return rows;
+
+      return orderBy(
+        rows,
+        [
+          (row) => {
+            if (column?.sortValue) {
+              return column.sortValue(row.data);
+            }
+            return get(row.data, currentSortKey);
+          },
+        ],
+        [sortOrder]
+      );
+    };
+  }, [columns, currentSortKey, sortOrder]);
+
+  return {
+    currentSortKey,
+    handleSort,
+    sortOrder,
+    sortRows,
+  };
+};


### PR DESCRIPTION
정렬과 즐겨찾기 로직이 컴포넌트에 직접 포함되어 가독성이 떨어지고 재사용이 어려웠음

- useTableSort: 정렬 상태 관리 및 행 정렬 로직 분리
- useFavoriteRows: 즐겨찾기 행 분리 로직 추출
- getRowProps 타입을 ComponentPropsWithoutRef로 개선

fix #268