### PR TITLE
refactor(frontend): Content 필터 컴포넌트 중복 제거 및 공통화

### DIFF
--- a/src/frontend/src/domains/content/components/content-wage-section.tsx
+++ b/src/frontend/src/domains/content/components/content-wage-section.tsx
@@ -1,0 +1,149 @@
+import { Flex, IconButton, Text } from "@chakra-ui/react";
+import { Suspense } from "react";
+import { IoFilter } from "react-icons/io5";
+import { LuPencilLine } from "react-icons/lu";
+
+import { Button } from "~/components/chakra/ui/button";
+import { Field } from "~/components/chakra/ui/field";
+import {
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "~/components/chakra/ui/popover";
+import { DataGrid } from "~/components/data-grid";
+import { Dialog } from "~/components/dialog";
+import { TextLoader } from "~/components/loader";
+import { Section } from "~/components/section";
+import { LoginTooltip } from "~/components/tooltip";
+import { useAuth } from "~/libs/auth";
+import { useSafeQuery } from "~/libs/graphql";
+import { ContentDetailsDialogWageSectionDocument } from "~/libs/graphql/generated";
+
+import { ContentDurationEditDialog } from "../content-duration-edit-dialog";
+import { BooleanFilter, ItemsFilter } from "../filters";
+import { useWageFilter } from "../hooks";
+import { RewardItem } from "../types";
+
+type ContentWageSectionProps = {
+  contentId: number;
+  items: RewardItem[];
+};
+
+export const ContentWageSection = ({ contentId, items }: ContentWageSectionProps) => {
+  const filter = useWageFilter(items);
+
+  return (
+    <Section
+      title={
+        <Flex alignItems="center" gap={4}>
+          시급 정보{" "}
+          <PopoverRoot positioning={{ placement: "right-end" }}>
+            <PopoverTrigger asChild>
+              <Button size="xs" variant="outline">
+                <IoFilter />
+                필터
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent portalled={false}>
+              <PopoverArrow />
+              <PopoverBody>
+                <Flex direction="column" gap={4}>
+                  <Field label="컨텐츠 보상 종류" w="auto">
+                    <ItemsFilter
+                      items={items}
+                      onChange={filter.setIncludeItemIds}
+                      value={filter.includeItemIds}
+                    />
+                  </Field>
+                  <Field label="더보기 포함 여부" w="auto">
+                    <BooleanFilter
+                      onChange={filter.setIncludeSeeMore}
+                      value={filter.includeSeeMore}
+                    />
+                  </Field>
+                  <Field label="귀속 재료 포함 여부" w="auto">
+                    <BooleanFilter onChange={filter.setIncludeBound} value={filter.includeBound} />
+                  </Field>
+                </Flex>
+              </PopoverBody>
+            </PopoverContent>
+          </PopoverRoot>
+        </Flex>
+      }
+    >
+      <Suspense fallback={<TextLoader />}>
+        <ContentWageDataGrid
+          contentId={contentId}
+          includeBound={filter.includeBound}
+          includeItemIds={filter.includeItemIds}
+          includeSeeMore={filter.includeSeeMore}
+        />
+      </Suspense>
+    </Section>
+  );
+};
+
+type ContentWageDataGridProps = {
+  contentId: number;
+  includeBound: boolean;
+  includeItemIds: number[];
+  includeSeeMore: boolean;
+};
+
+const ContentWageDataGrid = ({
+  contentId,
+  includeBound,
+  includeItemIds,
+  includeSeeMore,
+}: ContentWageDataGridProps) => {
+  const { isAuthenticated } = useAuth();
+  const { data, refetch } = useSafeQuery(ContentDetailsDialogWageSectionDocument, {
+    variables: {
+      contentId,
+      filter: {
+        includeBound,
+        includeItemIds,
+        includeSeeMore,
+      },
+    },
+  });
+
+  const wageItems = [
+    {
+      label: "소요 시간",
+      value: (
+        <Flex alignItems="center" gap={2}>
+          <Text>{data.content.durationText}</Text>
+          <Dialog.Trigger
+            dialog={ContentDurationEditDialog}
+            dialogProps={{
+              contentId,
+              onComplete: refetch,
+            }}
+            disabled={!isAuthenticated}
+          >
+            <LoginTooltip>
+              <IconButton
+                disabled={!isAuthenticated}
+                h={4}
+                minW={4}
+                p={0}
+                size="2xs"
+                variant="ghost"
+              >
+                <LuPencilLine />
+              </IconButton>
+            </LoginTooltip>
+          </Dialog.Trigger>
+        </Flex>
+      ),
+    },
+    { label: "시급(원)", value: data.content.wage.krwAmountPerHour },
+    { label: "시급(골드)", value: data.content.wage.goldAmountPerHour },
+    { label: "1수당 골드", value: data.content.wage.goldAmountPerClear },
+  ];
+
+  return <DataGrid items={wageItems} />;
+};

--- a/src/frontend/src/domains/content/components/index.tsx
+++ b/src/frontend/src/domains/content/components/index.tsx
@@ -1,0 +1,1 @@
+export { ContentWageSection } from "./content-wage-section";

--- a/src/frontend/src/domains/content/content-details-dialog.tsx
+++ b/src/frontend/src/domains/content/content-details-dialog.tsx
@@ -1,37 +1,20 @@
 import { Flex, IconButton, Text } from "@chakra-ui/react";
-import { Suspense, useState } from "react";
 import { IoIosSettings } from "react-icons/io";
-import { IoFilter } from "react-icons/io5";
-import { LuPencilLine } from "react-icons/lu";
 
-import { Button } from "~/components/chakra/ui/button";
-import { Field } from "~/components/chakra/ui/field";
-import {
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
-} from "~/components/chakra/ui/popover";
-import { SegmentedControl } from "~/components/chakra/ui/segmented-control";
 import { DataGrid } from "~/components/data-grid";
 import { Dialog, DialogProps } from "~/components/dialog";
 import { DialogCloseButton } from "~/components/dialog/dialog-close-button";
-import { TextLoader } from "~/components/loader";
 import { Section } from "~/components/section";
-import { MultiSelect } from "~/components/select";
 import { LoginTooltip } from "~/components/tooltip";
 import { useAuth } from "~/libs/auth";
-import { useSafeQuery } from "~/libs/graphql";
 import {
   ContentDetailsDialogDocument,
   ContentDetailsDialogQuery,
   ContentDetailsDialogQueryVariables,
-  ContentDetailsDialogWageSectionDocument,
 } from "~/libs/graphql/generated";
 
 import { ItemNameWithImage } from "../item";
-import { ContentDurationEditDialog } from "./content-duration-edit-dialog";
+import { ContentWageSection } from "./components";
 import { ContentRewardEditDialog } from "./content-reward-edit-dialog";
 import { ContentSeeMoreRewardEditDialog } from "./content-see-more-reward-edit-dialog";
 
@@ -164,193 +147,5 @@ export const ContentDetailsDialog = ({
         );
       }}
     </Dialog>
-  );
-};
-
-const ContentWageSection = ({
-  contentId,
-  items,
-}: {
-  contentId: number;
-  items: { id: number; name: string }[];
-}) => {
-  const [includeSeeMore, setIncludeSeeMore] = useState(false);
-  const [includeBound, setIncludeBound] = useState(false);
-  const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map(({ id }) => id));
-
-  return (
-    <Section
-      title={
-        <Flex alignItems="center" gap={4}>
-          시급 정보{" "}
-          <PopoverRoot positioning={{ placement: "right-end" }}>
-            <PopoverTrigger asChild>
-              <Button size="xs" variant="outline">
-                <IoFilter />
-                필터
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent portalled={false}>
-              <PopoverArrow />
-              <PopoverBody>
-                <Flex direction="column" gap={4}>
-                  <Field label="컨텐츠 보상 종류" w="auto">
-                    <ItemsFilter
-                      includeItemIds={includeItemIds}
-                      items={items}
-                      setIncludeItemIds={setIncludeItemIds}
-                    />
-                  </Field>
-                  <Field label="더보기 포함 여부" w="auto">
-                    <ContentSeeMoreFilter
-                      includeSeeMore={includeSeeMore}
-                      setIncludeSeeMore={setIncludeSeeMore}
-                    />
-                  </Field>
-                  <Field label="귀속 재료 포함 여부" w="auto">
-                    <ContentIsBoundFilter
-                      includeBound={includeBound}
-                      setIncludeBound={setIncludeBound}
-                    />
-                  </Field>
-                </Flex>
-              </PopoverBody>
-            </PopoverContent>
-          </PopoverRoot>
-        </Flex>
-      }
-    >
-      <Suspense fallback={<TextLoader />}>
-        <ContentWageSectionDataGrid
-          contentId={contentId}
-          includeBound={includeBound}
-          includeItemIds={includeItemIds}
-          includeSeeMore={includeSeeMore}
-        />
-      </Suspense>
-    </Section>
-  );
-};
-
-const ContentWageSectionDataGrid = ({
-  contentId,
-  includeBound,
-  includeItemIds,
-  includeSeeMore,
-}: {
-  contentId: number;
-  includeBound: boolean;
-  includeItemIds: number[];
-  includeSeeMore: boolean;
-}) => {
-  const { isAuthenticated } = useAuth();
-  const { data, refetch } = useSafeQuery(ContentDetailsDialogWageSectionDocument, {
-    variables: {
-      contentId,
-      filter: {
-        includeBound,
-        includeItemIds,
-        includeSeeMore,
-      },
-    },
-  });
-
-  const wageItems = [
-    {
-      label: "소요 시간",
-      value: (
-        <Flex alignItems="center" gap={2}>
-          <Text>{data.content.durationText}</Text>
-          <Dialog.Trigger
-            dialog={ContentDurationEditDialog}
-            dialogProps={{
-              contentId,
-              onComplete: refetch,
-            }}
-            disabled={!isAuthenticated}
-          >
-            <LoginTooltip>
-              <IconButton
-                disabled={!isAuthenticated}
-                h={4}
-                minW={4}
-                p={0}
-                size="2xs"
-                variant="ghost"
-              >
-                <LuPencilLine />
-              </IconButton>
-            </LoginTooltip>
-          </Dialog.Trigger>
-        </Flex>
-      ),
-    },
-    { label: "시급(원)", value: data.content.wage.krwAmountPerHour },
-    { label: "시급(골드)", value: data.content.wage.goldAmountPerHour },
-    { label: "1수당 골드", value: data.content.wage.goldAmountPerClear },
-  ];
-
-  return <DataGrid items={wageItems} />;
-};
-
-const ContentSeeMoreFilter = ({
-  includeSeeMore,
-  setIncludeSeeMore,
-}: {
-  includeSeeMore: boolean;
-  setIncludeSeeMore: (value: boolean) => void;
-}) => {
-  return (
-    <SegmentedControl
-      items={[
-        { label: "미포함", value: "false" },
-        { label: "포함", value: "true" },
-      ]}
-      onValueChange={(e) => setIncludeSeeMore(e.value === "true")}
-      value={includeSeeMore ? "true" : "false"}
-    />
-  );
-};
-
-const ContentIsBoundFilter = ({
-  includeBound,
-  setIncludeBound,
-}: {
-  includeBound: boolean;
-  setIncludeBound: (value: boolean) => void;
-}) => {
-  return (
-    <SegmentedControl
-      items={[
-        { label: "미포함", value: "false" },
-        { label: "포함", value: "true" },
-      ]}
-      onValueChange={(e) => setIncludeBound(e.value === "true")}
-      value={includeBound ? "true" : "false"}
-    />
-  );
-};
-
-const ItemsFilter = ({
-  includeItemIds,
-  items: rewardItems,
-  setIncludeItemIds,
-}: {
-  includeItemIds: number[];
-  items: { id: number; name: string }[];
-  setIncludeItemIds: (value: number[]) => void;
-}) => {
-  const items = rewardItems.map(({ id, name }) => ({
-    label: name,
-    value: id,
-  }));
-
-  return (
-    <MultiSelect
-      items={items}
-      onChange={setIncludeItemIds}
-      placeholder="보상 아이템 선택"
-      value={includeItemIds}
-    />
   );
 };

--- a/src/frontend/src/domains/content/content-group-details-dialog.tsx
+++ b/src/frontend/src/domains/content/content-group-details-dialog.tsx
@@ -1,38 +1,24 @@
 import { Flex, IconButton, Text } from "@chakra-ui/react";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import { IoIosSettings } from "react-icons/io";
-import { IoFilter } from "react-icons/io5";
-import { LuPencilLine } from "react-icons/lu";
 
-import { Button } from "~/components/chakra/ui/button";
-import { Field } from "~/components/chakra/ui/field";
-import {
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
-} from "~/components/chakra/ui/popover";
-import { SegmentedControl } from "~/components/chakra/ui/segmented-control";
 import { DataGrid } from "~/components/data-grid";
 import { Dialog, DialogProps } from "~/components/dialog";
 import { DialogCloseButton } from "~/components/dialog/dialog-close-button";
 import { TextLoader } from "~/components/loader";
 import { Section } from "~/components/section";
-import { MultiSelect } from "~/components/select";
 import { LoginTooltip } from "~/components/tooltip";
 import { useAuth } from "~/libs/auth";
 import { useSafeQuery } from "~/libs/graphql";
 import {
   ContentDetailsDialogDocument,
-  ContentDetailsDialogWageSectionDocument,
   ContentGroupDetailsDialogDocument,
   ContentGroupDetailsDialogQuery,
   ContentGroupDetailsDialogQueryVariables,
 } from "~/libs/graphql/generated";
 
 import { ItemNameWithImage } from "../item";
-import { ContentDurationEditDialog } from "./content-duration-edit-dialog";
+import { ContentWageSection } from "./components";
 import { ContentRewardEditDialog } from "./content-reward-edit-dialog";
 import { ContentSeeMoreRewardEditDialog } from "./content-see-more-reward-edit-dialog";
 
@@ -182,193 +168,5 @@ const ContentGroupSection = ({ contentId }: { contentId: number }) => {
         </Section>
       )}
     </Flex>
-  );
-};
-
-const ContentWageSection = ({
-  contentId,
-  items,
-}: {
-  contentId: number;
-  items: { id: number; name: string }[];
-}) => {
-  const [includeSeeMore, setIncludeSeeMore] = useState(false);
-  const [includeBound, setIncludeBound] = useState(false);
-  const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map(({ id }) => id));
-
-  return (
-    <Section
-      title={
-        <Flex alignItems="center" gap={4}>
-          시급 정보{" "}
-          <PopoverRoot positioning={{ placement: "right-end" }}>
-            <PopoverTrigger asChild>
-              <Button size="xs" variant="outline">
-                <IoFilter />
-                필터
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent portalled={false}>
-              <PopoverArrow />
-              <PopoverBody>
-                <Flex direction="column" gap={4}>
-                  <Field label="컨텐츠 보상 종류" w="auto">
-                    <ItemsFilter
-                      includeItemIds={includeItemIds}
-                      items={items}
-                      setIncludeItemIds={setIncludeItemIds}
-                    />
-                  </Field>
-                  <Field label="더보기 포함 여부" w="auto">
-                    <ContentSeeMoreFilter
-                      includeSeeMore={includeSeeMore}
-                      setIncludeSeeMore={setIncludeSeeMore}
-                    />
-                  </Field>
-                  <Field label="귀속 재료 포함 여부" w="auto">
-                    <ContentIsBoundFilter
-                      includeBound={includeBound}
-                      setIncludeBound={setIncludeBound}
-                    />
-                  </Field>
-                </Flex>
-              </PopoverBody>
-            </PopoverContent>
-          </PopoverRoot>
-        </Flex>
-      }
-    >
-      <Suspense fallback={<TextLoader />}>
-        <ContentWageSectionDataGrid
-          contentId={contentId}
-          includeBound={includeBound}
-          includeItemIds={includeItemIds}
-          includeSeeMore={includeSeeMore}
-        />
-      </Suspense>
-    </Section>
-  );
-};
-
-const ContentWageSectionDataGrid = ({
-  contentId,
-  includeBound,
-  includeItemIds,
-  includeSeeMore,
-}: {
-  contentId: number;
-  includeBound: boolean;
-  includeItemIds: number[];
-  includeSeeMore: boolean;
-}) => {
-  const { isAuthenticated } = useAuth();
-  const { data, refetch } = useSafeQuery(ContentDetailsDialogWageSectionDocument, {
-    variables: {
-      contentId,
-      filter: {
-        includeBound,
-        includeItemIds,
-        includeSeeMore,
-      },
-    },
-  });
-
-  const wageItems = [
-    {
-      label: "소요 시간",
-      value: (
-        <Flex alignItems="center" gap={2}>
-          <Text>{data.content.durationText}</Text>
-          <Dialog.Trigger
-            dialog={ContentDurationEditDialog}
-            dialogProps={{
-              contentId,
-              onComplete: refetch,
-            }}
-            disabled={!isAuthenticated}
-          >
-            <LoginTooltip>
-              <IconButton
-                disabled={!isAuthenticated}
-                h={4}
-                minW={4}
-                p={0}
-                size="2xs"
-                variant="ghost"
-              >
-                <LuPencilLine />
-              </IconButton>
-            </LoginTooltip>
-          </Dialog.Trigger>
-        </Flex>
-      ),
-    },
-    { label: "시급(원)", value: data.content.wage.krwAmountPerHour },
-    { label: "시급(골드)", value: data.content.wage.goldAmountPerHour },
-    { label: "1수당 골드", value: data.content.wage.goldAmountPerClear },
-  ];
-
-  return <DataGrid items={wageItems} />;
-};
-
-const ContentSeeMoreFilter = ({
-  includeSeeMore,
-  setIncludeSeeMore,
-}: {
-  includeSeeMore: boolean;
-  setIncludeSeeMore: (value: boolean) => void;
-}) => {
-  return (
-    <SegmentedControl
-      items={[
-        { label: "미포함", value: "false" },
-        { label: "포함", value: "true" },
-      ]}
-      onValueChange={(e) => setIncludeSeeMore(e.value === "true")}
-      value={includeSeeMore ? "true" : "false"}
-    />
-  );
-};
-
-const ContentIsBoundFilter = ({
-  includeBound,
-  setIncludeBound,
-}: {
-  includeBound: boolean;
-  setIncludeBound: (value: boolean) => void;
-}) => {
-  return (
-    <SegmentedControl
-      items={[
-        { label: "미포함", value: "false" },
-        { label: "포함", value: "true" },
-      ]}
-      onValueChange={(e) => setIncludeBound(e.value === "true")}
-      value={includeBound ? "true" : "false"}
-    />
-  );
-};
-
-const ItemsFilter = ({
-  includeItemIds,
-  items: rewardItems,
-  setIncludeItemIds,
-}: {
-  includeItemIds: number[];
-  items: { id: number; name: string }[];
-  setIncludeItemIds: (value: number[]) => void;
-}) => {
-  const items = rewardItems.map(({ id, name }) => ({
-    label: name,
-    value: id,
-  }));
-
-  return (
-    <MultiSelect
-      items={items}
-      onChange={setIncludeItemIds}
-      placeholder="보상 아이템 선택"
-      value={includeItemIds}
-    />
   );
 };

--- a/src/frontend/src/domains/content/filters/boolean-filter.tsx
+++ b/src/frontend/src/domains/content/filters/boolean-filter.tsx
@@ -1,0 +1,30 @@
+import { SegmentedControl } from "~/components/chakra/ui/segmented-control";
+
+type BooleanFilterLabels = {
+  false: string;
+  true: string;
+};
+
+type BooleanFilterProps = {
+  labels?: BooleanFilterLabels;
+  onChange: (value: boolean) => void;
+  value: boolean;
+};
+
+const DEFAULT_LABELS: BooleanFilterLabels = {
+  false: "미포함",
+  true: "포함",
+};
+
+export const BooleanFilter = ({ labels = DEFAULT_LABELS, onChange, value }: BooleanFilterProps) => {
+  return (
+    <SegmentedControl
+      items={[
+        { label: labels.false, value: "false" },
+        { label: labels.true, value: "true" },
+      ]}
+      onValueChange={(e) => onChange(e.value === "true")}
+      value={value ? "true" : "false"}
+    />
+  );
+};

--- a/src/frontend/src/domains/content/filters/index.tsx
+++ b/src/frontend/src/domains/content/filters/index.tsx
@@ -1,0 +1,2 @@
+export { BooleanFilter } from "./boolean-filter";
+export { ItemsFilter } from "./items-filter";

--- a/src/frontend/src/domains/content/filters/items-filter.tsx
+++ b/src/frontend/src/domains/content/filters/items-filter.tsx
@@ -1,0 +1,24 @@
+import { MultiSelect } from "~/components/select";
+
+import { RewardItem } from "../types";
+
+type ItemsFilterProps = {
+  items: RewardItem[];
+  onChange: (value: number[]) => void;
+  placeholder?: string;
+  value: number[];
+};
+
+export const ItemsFilter = ({
+  items: rewardItems,
+  onChange,
+  placeholder = "보상 아이템 선택",
+  value,
+}: ItemsFilterProps) => {
+  const items = rewardItems.map(({ id, name }) => ({
+    label: name,
+    value: id,
+  }));
+
+  return <MultiSelect items={items} onChange={onChange} placeholder={placeholder} value={value} />;
+};

--- a/src/frontend/src/domains/content/hooks/index.tsx
+++ b/src/frontend/src/domains/content/hooks/index.tsx
@@ -1,0 +1,1 @@
+export { useWageFilter } from "./use-wage-filter";

--- a/src/frontend/src/domains/content/hooks/use-wage-filter.tsx
+++ b/src/frontend/src/domains/content/hooks/use-wage-filter.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import { RewardItem } from "../types";
+
+type WageFilterState = {
+  includeBound: boolean;
+  includeItemIds: number[];
+  includeSeeMore: boolean;
+};
+
+type WageFilterActions = {
+  setIncludeBound: (value: boolean) => void;
+  setIncludeItemIds: (value: number[]) => void;
+  setIncludeSeeMore: (value: boolean) => void;
+};
+
+export const useWageFilter = (items: RewardItem[]): WageFilterState & WageFilterActions => {
+  const [includeBound, setIncludeBound] = useState(false);
+  const [includeItemIds, setIncludeItemIds] = useState<number[]>(items.map(({ id }) => id));
+  const [includeSeeMore, setIncludeSeeMore] = useState(false);
+
+  // items 변경 시 includeItemIds 동기화 (외부 prop 동기화)
+  useEffect(() => {
+    setIncludeItemIds(items.map(({ id }) => id));
+  }, [items]);
+
+  return {
+    includeBound,
+    includeItemIds,
+    includeSeeMore,
+    setIncludeBound,
+    setIncludeItemIds,
+    setIncludeSeeMore,
+  };
+};

--- a/src/frontend/src/domains/content/types.tsx
+++ b/src/frontend/src/domains/content/types.tsx
@@ -1,0 +1,4 @@
+export type RewardItem = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
두 다이얼로그 컴포넌트에서 동일한 필터 UI가 중복 구현되어 있었음 (content-details-dialog, content-group-details-dialog 각각 ~180줄씩 중복)

공통 컴포넌트로 분리하여 재사용성 개선:
- BooleanFilter: 더보기/귀속 포함 토글 통합
- ItemsFilter: 보상 아이템 멀티셀렉트 래퍼
- useWageFilter: 필터 상태 관리 훅 (items 변경 시 동기화 포함)
- ContentWageSection: 시급 정보 섹션 통합 컴포넌트
- RewardItem 타입 통합으로 중복 정의 제거

fix #272